### PR TITLE
[#90] Add -v0 to hsctl migrate steps.

### DIFF
--- a/hsctl
+++ b/hsctl
@@ -244,9 +244,9 @@ loaddb_hs() {
 migrate_hs() {
     echo "MIGRATE:"
     echo "  - docker exec -u hydro-service hydroshare python manage.py migrate sites"
-    docker exec -u hydro-service hydroshare python manage.py migrate sites
+    docker exec -u hydro-service hydroshare python manage.py migrate -v0 sites
     echo "  - docker exec -u hydro-service hydroshare python manage.py migrate --fake-initial"
-    docker exec -u hydro-service hydroshare python manage.py migrate --fake-initial
+    docker exec -u hydro-service hydroshare python manage.py migrate -v0 --fake-initial
     echo "  - docker exec -u hydro-service hydroshare python manage.py fix_permissions"
     docker exec -u hydro-service hydroshare python manage.py fix_permissions
 }


### PR DESCRIPTION
This makes the rebuild commands much faster.