### PR TITLE
#96 Fix 500 Error on File Upload

### DIFF
--- a/hs_core/templates/pages/create-resource.html
+++ b/hs_core/templates/pages/create-resource.html
@@ -259,6 +259,9 @@
                                     <span>To load files from an iRODS server including your iRODS user MyHPOM server:</span>
                                     -->
                                     <div id="irods-browse">
+                                        <!-- These hidden fields are added to avoid errors -->
+                                        <input type="hidden" id="irods_file_names" name="irods_file_names" value="">
+                                        <input type="hidden" id="irods_federated" name="irods_federated" value="">
                                     <!--
                                         <div id="log-into-irods">
                                             <a id="btn-signin-irods" type="button" class="btn btn-info"

--- a/hs_core/templates/pages/create-resource.html
+++ b/hs_core/templates/pages/create-resource.html
@@ -215,6 +215,7 @@
                               action="/hsapi/_internal/create-resource/do/">
                             {% csrf_token %}
 
+
                             <div class="hs-dropzone-header">
                                 <i class="fa fa-info-circle" aria-hidden="true"></i>
                                 <span class="hs-dropzone-header-help">Drop files below or click to upload.</span>
@@ -225,6 +226,10 @@
                             </div>
 
                             <div class="hs-dropzone-wrapper">
+                                <div class="hs-upload-indicator text-center">
+                                    <i class="fa fa-file" aria-hidden="true"></i>
+                                    <h3>Drop files here or click to upload</h3>
+                                </div>
                                 <div id="dz-container">
                                     <input id="form-title" type="hidden" name="title" value=""/>
                                     {# Defaults to CompositeResource #}
@@ -661,6 +666,6 @@
     <script type="text/javascript" src="{{ STATIC_URL }}js/dropzone.js"></script>
     {% block extra_js %}
         {{ block.super }}
-        <script type="text/javascript" src="{{ STATIC_URL }}js/create-resource.js"></script>
+        <script type="text/javascript" src="{{ STATIC_URL }}js/create-resource-hydro.js"></script>
     {% endblock %}
 {% endblock %}

--- a/hs_core/views/__init__.py
+++ b/hs_core/views/__init__.py
@@ -1079,36 +1079,39 @@ def create_resource_select_resource_type(request, *args, **kwargs):
 @login_required
 def create_resource(request, *args, **kwargs):
     # Note: This view function must be called by ajax
-
     ajax_response_data = {'status': 'error', 'message': ''}
     resource_type = request.POST['resource-type']
     res_title = request.POST['title']
     resource_files = request.FILES.values()
     source_names = []
-    irods_fnames = request.POST.get('irods_file_names')
-    federated = request.POST.get("irods_federated").lower() == 'true'
+
+    # NOTE: We want to remove any access that users have to upload a file from
+    # iRods, so this following code is irrelevant to a front-facing create_resource method
+
+    # irods_fnames = request.POST.get('irods_file_names')
+    # federated = request.POST.get("irods_federated").lower() == 'true'
     # TODO: need to make REST API consistent with internal API. This is just "move" now there.
     fed_copy_or_move = request.POST.get("copy-or-move")
 
-    if irods_fnames:
-        if federated:
-            source_names = irods_fnames.split(',')
-        else:
-            user = request.POST.get('irods-username')
-            password = request.POST.get("irods-password")
-            port = request.POST.get("irods-port")
-            host = request.POST.get("irods-host")
-            zone = request.POST.get("irods-zone")
-            try:
-                upload_from_irods(username=user, password=password, host=host, port=port,
-                                  zone=zone, irods_fnames=irods_fnames, res_files=resource_files)
-            except utils.ResourceFileSizeException as ex:
-                ajax_response_data['message'] = ex.message
-                return JsonResponse(ajax_response_data)
+    # if irods_fnames:
+    #     if federated:
+    #         source_names = irods_fnames.split(',')
+    #     else:
+    #         user = request.POST.get('irods-username')
+    #         password = request.POST.get("irods-password")
+    #         port = request.POST.get("irods-port")
+    #         host = request.POST.get("irods-host")
+    #         zone = request.POST.get("irods-zone")
+    #         try:
+    #             upload_from_irods(username=user, password=password, host=host, port=port,
+    #                               zone=zone, irods_fnames=irods_fnames, res_files=resource_files)
+    #         except utils.ResourceFileSizeException as ex:
+    #             ajax_response_data['message'] = ex.message
+    #             return JsonResponse(ajax_response_data)
 
-            except SessionException as ex:
-                ajax_response_data['message'] = ex.stderr
-                return JsonResponse(ajax_response_data)
+    #         except SessionException as ex:
+    #             ajax_response_data['message'] = ex.stderr
+    #             return JsonResponse(ajax_response_data)
 
     url_key = "page_redirect_url"
     try:

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -4449,6 +4449,21 @@ span.caption-file-type {
 	resize: vertical;
 	border: 0;
 }
+
+.hs-upload-indicator {
+  position: absolute;
+  color: #777;
+  top: 125px;
+  padding: 20px;
+  width: calc(100% - 20px);
+  pointer-events: none;
+  text-shadow: 0 1px rgba(255, 255, 255, 0.6);
+}
+
+.hs-upload-indicator > i {
+  font-size: 40px;
+}
+
 .fb-loading-spinner {
 	list-style: none;
     width: 100%;
@@ -4506,6 +4521,7 @@ span.caption-file-type {
 
 .hs-dropzone-wrapper {
 	height: 350px;
+  min-height: 350px;
 	border: 1px solid #DDD;
 	overflow: auto;
 	resize: vertical;


### PR DESCRIPTION
The form processing aspects were still looking for some iRods upload related data that had been commented out of the template/form.  commenting out those parts on the receiving end fixed the 500 error.  Resources are now able to be uploaded.  

In addition, was able to add a few other aspects of the Dropzone features in, according to what javascript that Hydroshare is currently using.   