### PR TITLE
[#92] Support local development options.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 LOCAL_SETTINGS=dev_settings
 # Override the hsctl settings:
 # CONFIG_FILE=config/hydroshare-config.yaml
+
+# Other common overrides:
+# UID=1000
+# GID=1000
+# HOME_DIR=/hydro/hydroshare

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+LOCAL_SETTINGS=dev_settings
+# Override the hsctl settings:
+# CONFIG_FILE=config/hydroshare-config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,12 @@
 .coverage
 .DS_Store
 .idea
+.env
 /celery
 /config/hydroshare-config.sh
 /config/hydroshare-config.yaml
 /hydroshare/local_settings.py
+/hydroshare/dev_settings.py
 /hydroshare/static
 /log
 /nginx/config-files/hs-nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN pip install --upgrade pip && pip install djangorestframework==3.6.4
 RUN pip install \
   robot_detection \
   django-ipware \
-  django-test-without-migrations
+  django-test-without-migrations \
+  python-dotenv
 
 # Patch for Mezzanone 4.10 collecttemplates bugfix
 RUN echo -e "\

--- a/README.md
+++ b/README.md
@@ -17,3 +17,34 @@ MyHPOM is a collaborative website being developed for better management of perso
 If you want to contribute to MyHPOM, please see the [MyHPOM Wiki](https://github.com/SoftwareResearchInstitute/MyHPOM/wiki/).
 
 More information can be found in the [MyHPOM Wiki](https://github.com/SoftwareResearchInstitute/MyHPOM/wiki/).
+
+Environments
+============
+
+This project is set up to read environmental settings from your .env file.
+Common configurable settings will be picked up from this file.
+
+Development
+-----------
+
+To get started with your own configurable developer setup perform the following
+commands:
+
+```shell
+
+cp ./.env.example .env
+cp ./hydroshare/dev_settings.example.py ./hydroshare/dev_settings.py
+```
+
+Once these changes are made you can customize your development environment
+within your dev_settings.py (which will not be added to git).
+
+Deployment
+----------
+
+Deployments settings can also take advantage of dotenv based settings by
+specifying any variables directly in a .env file.
+
+You can also use the .env file to specify a different hydroshare-config.yaml
+derived file (i.e., a production version).
+

--- a/config/hydroshare-config.yaml
+++ b/config/hydroshare-config.yaml
@@ -1,10 +1,10 @@
 ### Local Configuration Variables ###
-HS_PATH: /home/hydro/hydroshare
-HOST_SSL_DIR: /home/hydro/hs-certs
+HS_PATH: $HOME_DIR
+HOST_SSL_DIR: $HS_PATH/hs-certs
 HS_DATABASE: pg.myhpomdevelopment.sql
-HS_LOG_FILES: /home/hydro/hydroshare/log
-HS_SERVICE_UID: 1000
-HS_SERVICE_GID: 1000
+HS_LOG_FILES: $HS_PATH/log
+HS_SERVICE_UID: $UID
+HS_SERVICE_GID: $GID
 
 ### Deployment Options ###
 USE_NGINX: false
@@ -14,10 +14,10 @@ USE_HTTP_AUTH: false
 
 ### nginx Configuration Variables ###
 FQDN_OR_IP: localhost
-NGINX_DIR: /home/hydro/hydroshare/nginx
+NGINX_DIR: $HS_PATH/nginx
 
 ### SSL Configuration Variables ###
-SSL_CERT_DIR: /home/hydro/hydroshare/nginx/cert-files
+SSL_CERT_DIR: $HS_PATH/nginx/cert-files
 SSL_CERT_FILE: hydrodev-vb.example.org.cert
 SSL_KEY_FILE: hydrodev-vb.example.org.key
 

--- a/hsctl
+++ b/hsctl
@@ -5,15 +5,21 @@
 # Author: Michael Stealey <michael.j.stealey@gmail.com>
 
 ### Local Config ###
+
 CONFIG_DIRECTORY='./config'
 CONFIG_FILE=${CONFIG_DIRECTORY}'/hydroshare-config.yaml'
 HOME_DIR=${PWD}
+
+# Read any CONFIG_FILE overrides from the local environment:
+if [ -f .env ]; then
+    source .env
+fi
 
 # Read hydroshare-config.yaml into environment
 sed -e "s/:[^:\/\/]/=/g;s/$//g;s/ *=/=/g" ${CONFIG_FILE} > $CONFIG_DIRECTORY/hydroshare-config.sh
 sed -i 's/#.*$//' ${CONFIG_DIRECTORY}/hydroshare-config.sh
 sed -i '/^\s*$/d' ${CONFIG_DIRECTORY}/hydroshare-config.sh
-while read line; do export $line; done < <(cat ${CONFIG_DIRECTORY}/hydroshare-config.sh)
+source ${CONFIG_DIRECTORY}/hydroshare-config.sh
 
 ### Docker Variables ###
 HS_DOCKER_CONTAINERS=(hydroshare defaultworker)

--- a/hsctl
+++ b/hsctl
@@ -10,6 +10,9 @@ CONFIG_DIRECTORY='./config'
 CONFIG_FILE=${CONFIG_DIRECTORY}'/hydroshare-config.yaml'
 HOME_DIR=${PWD}
 
+# by default use the same group id as the user id:
+GID=$UID
+
 # Read any CONFIG_FILE overrides from the local environment:
 if [ -f .env ]; then
     source .env

--- a/hydroshare/dev_settings.example.py
+++ b/hydroshare/dev_settings.example.py
@@ -1,0 +1,12 @@
+from hydroshare.local_settings import *   # NOQA
+
+# These secret keys are used by the pg.myhpomdevelopment.sql development dump,
+# if you change these, you will not be able to login with users setup in the
+# dump:
+SECRET_KEY = '9e2e3c2d-8282-41b2-a027-de304c0bc3d944963c9a-4778-43e0-947c-38889e976dcab9f328cb-1576-4314-bfa6-70c42a6e773c'
+NEVERCACHE_KEY = '7b205669-41dd-40db-9b96-c6f93b66123496a56be1-607f-4dbf-bf62-3315fb353ce6f12a7d28-06ad-4ef7-9266-b5ea66ed2519'
+
+DEBUG = True
+
+NEVERCACHE_KEY='dev_nevercache_key'
+SECRET_KEY='dev_secret_key'

--- a/hydroshare/local_settings.py
+++ b/hydroshare/local_settings.py
@@ -8,14 +8,20 @@ import os
 from kombu import Queue, Exchange
 from kombu.common import Broadcast
 
-DEBUG = True
+DEBUG = os.environ.get('DEBUG') == 'True'
 
-# DEVELOPMENT EXAMPLE ONLY
-# Make these unique, and don't share it with anybody
-SECRET_KEY = "9e2e3c2d-8282-41b2-a027-de304c0bc3d944963c9a-4778-43e0-947c-38889e976dcab9f328cb-1576-4314-bfa6-70c42a6e773c"
-NEVERCACHE_KEY = "7b205669-41dd-40db-9b96-c6f93b66123496a56be1-607f-4dbf-bf62-3315fb353ce6f12a7d28-06ad-4ef7-9266-b5ea66ed2519"
+# These secret keys are used by the pg.myhpomdevelopment.sql development dump,
+# if you change these, you will not be able to login with users setup in the
+# dump:
+# TODO These should not be a part of any production configuration, as anyone that
+# gets a copy of the git repository will be able to access passwords on the
+# sysstem. They should ultimately be a part of the dev settings template.
+SECRET_KEY = os.environ.get('SECRET_KEY', '9e2e3c2d-8282-41b2-a027-de304c0bc3d944963c9a-4778-43e0-947c-38889e976dcab9f328cb-1576-4314-bfa6-70c42a6e773c')
+NEVERCACHE_KEY = os.environ.get('NEVERCACHE_KEY', '7b205669-41dd-40db-9b96-c6f93b66123496a56be1-607f-4dbf-bf62-3315fb353ce6f12a7d28-06ad-4ef7-9266-b5ea66ed2519')
 
-ALLOWED_HOSTS = "*"
+# TODO we should not allow any host by default, as it represents a security
+# risk. See the Django docs: http://devdocs.io/django~1.8/ref/settings#std:setting-ALLOWED_HOSTS
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '*')
 
 RABBITMQ_HOST = os.environ.get('RABBITMQ_PORT_5672_TCP_ADDR', 'localhost')
 RABBITMQ_PORT = '5672'
@@ -164,15 +170,19 @@ HS_WWW_IRODS_ZONE = ''
 HS_USER_IRODS_ZONE = 'hydroshareuserZone'
 
 # Email configuration
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-#EMAIL_HOST_USER = ''
-#EMAIL_HOST_PASSWORD = ''
-#EMAIL_HOST = ''
-#EMAIL_PORT = ''
-#EMAIL_USE_TLS = True
-#DEFAULT_FROM_EMAIL = ''
-#DEFAULT_SUPPORT_EMAIL=''
+EMAIL_BACKEND = os.environ.get('EMAIL_BACKEND', 'django.core.mail.backends.console.EmailBackend')
+EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
+EMAIL_HOST = os.environ.get('EMAIL_HOST')
+EMAIL_PORT = int(os.environ.get('EMAIL_PORT', 0))
+EMAIL_USE_TLS = os.environ.get('EMAIL_USE_TLS', 'True') == 'True'
+DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL')
+DEFAULT_SUPPORT_EMAIL = os.environ.get('DEFAULT_SUPPORT_EMAIL')
 
-HYDROSHARE_SHARED_TEMP = '/shared_tmp'
+HYDROSHARE_SHARED_TEMP = os.environ.get('HYDROSHARE_SHARED_TEMP', '/shared_tmp')
 
 TIME_ZONE = "Etc/UTC"
+
+RECAPTCHA_VERIFY_URL='https://www.google.com/recaptcha/api/siteverify'
+RECAPTCHA_SITE_KEY=os.environ.get('RECAPTCHA_SITE_KEY')
+RECAPTCHA_SECRET_KEY=os.environ.get('RECAPTCHA_SECRET_KEY')

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -5,6 +5,9 @@ TEST_WITHOUT_MIGRATIONS_COMMAND = 'django_nose.management.commands.test.Command'
 
 import os
 import importlib
+from dotenv import load_dotenv
+
+load_dotenv()
 
 local_settings_module = os.environ.get('LOCAL_SETTINGS', 'hydroshare.local_settings')
 


### PR DESCRIPTION
This commit supports the ability to specify different settings without
modifying files that are under version control. Changes:

 * By default the hsctl will use paths and settings specific to the
   current working directory and the current user. This allows the hctl
   command to work within VirtualBox, and outside it (if you have docker
   and gnu sed installed)

 * Introduces support for a .env file (see the README) to override
   various options (listed further on)

 * The ability to change which hydroshare-config.yaml is used by
   specifying a different path in the .env file.

 * The ability to use a different django settings file by specifying it
   in the .env file.

 * Creates a new dev_settings.example.py template that local developers
   can use to override/customize their environments in development.

 * Many settings.py settings that one would want to override in
   production or local development have been made configurable via
   environmental variables (but ideally one would do this via the .env
   file or their own custom settings.py file)