### PR TITLE
[#105] Seemingly endless upload with no files

### DIFF
--- a/hs_core/templates/pages/create-resource.html
+++ b/hs_core/templates/pages/create-resource.html
@@ -194,6 +194,7 @@
                         -->
                     </ul>
                 </div>
+                <div id="ajax-upload-alert-container"></div>
             </div>
 
             <br>
@@ -442,9 +443,13 @@
 
                 init: function () {
                     myDropzone = this;
+                    var uploadAlertHTML = '<div class="alert alert-danger alert-dismissible" role="alert">' +
+                        '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span>' +
+                        '</button><strong>Failed to Upload Resources</strong></div>'
 
                     $(".btn-create-resource").click(function () {
-                        $("html, #dz-container").css("cursor", "progress");
+                        $("#dz-container").addClass("loading")
+                        $("#ajax-upload-alert-container").html('')
 
                         // Delete invalid files from queue before uploading
                         $(".dz-error .btn-remove").trigger("click");
@@ -473,6 +478,8 @@
                                 },
                                 error: function (response) {
                                     console.log(response);
+                                    $("#dz-container").removeClass("loading");
+                                    $("#ajax-upload-alert-container").html(uploadAlertHTML)
                                 }
                             });
                         }

--- a/theme/static/css/hydroshare_core.css
+++ b/theme/static/css/hydroshare_core.css
@@ -4539,6 +4539,29 @@ span.caption-file-type {
 	padding: 12px;
 	min-height: 100%;
 	border: 2px solid transparent;
+  position: relative;
+}
+
+#resource-content #dz-container::after {
+  content: url(/static/img/ajax-loader.gif);
+  position: absolute;
+  background: rgba(255, 255, 255, 0.8);
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  padding-top: 15%;
+  z-index: 2000;
+  display: none;
+}
+
+#resource-content #dz-container.loading {
+  pointer-events: none;
+}
+
+#resource-content #dz-container.loading::after {
+  display: block;
 }
 
 #resource-content .hs-dropzone-footer {


### PR DESCRIPTION
500 errors happening during ajax calls were not being dealt with.  

The 500 errors seem to be the biggest problem in the current state of our xdci-develop branch.  They happen if a user tries to push the `create resources` button without adding any files.  

This doesn't appear to be the same behavior in the current Hydroshare branch (However, there seem to be issues related to creating empty resources there.  Further discussion needed).  Even if the likely hood of getting 500 errors is minimized after merging in current hydroshare stuff, ultimately, this is an issue that does need to be dealt with.       

There were two other issues with how the resources were being created that were also not being dealt with. This PR fixes those issues as well.

1) The cursor would not be of the loading variety when hovering over certain elements that explicitly defined their own cursors.  Getting rid of cursor-as-loading indicator changes this, obviously. 
2) After a user clicks the `create resource` button (a.k.a. during loading) the user can add files to the dropzone.  Those files, however, are not part of the post data and will not be included.  To fix this, the dropzone was disabled during loading.   