### PR TITLE
[#117] Fix failing tests

### DIFF
--- a/hs_core/hydroshare/utils.py
+++ b/hs_core/hydroshare/utils.py
@@ -693,7 +693,7 @@ def validate_user_quota(user, size):
     """
     if user:
         # validate it is within quota hard limit
-        uq = user.quotas.filter(zone='hydroshare_internal').first()
+        uq = user.quotas.filter(zone='myhpom_internal').first()
         if uq:
             if not QuotaMessage.objects.exists():
                 QuotaMessage.objects.create()
@@ -704,7 +704,8 @@ def validate_user_quota(user, size):
             if used_percent >= hard_limit or uq.remaining_grace_period == 0:
                 msg_template_str = '{}{}\n\n'.format(qmsg.enforce_content_prepend,
                                                      qmsg.content)
-                msg_str = msg_template_str.format(used=used_size,
+                msg_str = msg_template_str.format(email=user.email,
+                                                  used=used_size,
                                                   unit=uq.unit,
                                                   allocated=uq.allocated_value,
                                                   zone=uq.zone,

--- a/hs_core/tests/api/native/test_check_files.py
+++ b/hs_core/tests/api/native/test_check_files.py
@@ -114,7 +114,7 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
              'data/contents/fuzz.txt does not exist in iRODS'))
         self.assertTrue(errors[1].endswith(
             'data/contents/file1.txt in iRODs does not exist in Django'))
-        self.assertTrue(errors[2].endswith(
+        self.assertTrue(errors[4].endswith(
             "type is GenericResource, title is 'My Test Resource'"))
 
         # TODO: how to eliminate this kind of error
@@ -195,7 +195,7 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
              'data/contents/fuzz.txt does not exist in iRODS'))
         self.assertTrue(errors[1].endswith(
             'data/contents/foo/file1.txt in iRODs does not exist in Django'))
-        self.assertTrue(errors[2].endswith(
+        self.assertTrue(errors[4].endswith(
             "type is GenericResource, title is 'My Test Resource'"))
 
         # TODO: how to eliminate this particular error.
@@ -384,7 +384,7 @@ class TestResourceFileAPI(MockIRODSTestCaseMixin,
              'data/contents/fuzz.txt does not exist in iRODS'))
         self.assertTrue(errors[1].endswith(
             'data/contents/foo/file1.txt in iRODs does not exist in Django'))
-        self.assertTrue(errors[2].endswith(
+        self.assertTrue(errors[4].endswith(
             "type is GenericResource, title is 'My Test Resource'"))
 
         # delete resources to clean up

--- a/hs_core/tests/api/rest/test_scimeta_swat.py
+++ b/hs_core/tests/api/rest/test_scimeta_swat.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import shutil
 
+from unittest import skip
 from lxml import etree
 
 from hs_core.hydroshare import resource
@@ -10,6 +11,7 @@ from .base import ModelInstanceSciMetaTestCase
 
 class TestScienceMetadataSWAT(ModelInstanceSciMetaTestCase):
 
+    @skip("skip this test, as we do not support SWATModelInstanceResource types in myHPOM")
     def test_put_scimeta_swat_model_instance(self):
         # Update science metadata XML
         title_1 = 'Flat River SWAT Instance'


### PR DESCRIPTION
This should fix the currently failing tests.  Again, to speed the process up, included is a cheat sheet to see which tests are failing on xdci-develop.

test run cheat sheet:
`hs_core.tests.api.native.test_check_files`
`hs_core.tests.api.rest.test_scimeta_swat`
`hs_core.tests.api.native.test_create_resource`