### PR TITLE
[#140] Set the local timezone to eastern.

### DIFF
--- a/hydroshare/local_settings.py
+++ b/hydroshare/local_settings.py
@@ -182,7 +182,7 @@ DEFAULT_SUPPORT_EMAIL = os.environ.get('DEFAULT_SUPPORT_EMAIL')
 
 HYDROSHARE_SHARED_TEMP = os.environ.get('HYDROSHARE_SHARED_TEMP', '/shared_tmp')
 
-TIME_ZONE = "Etc/UTC"
+TIME_ZONE = "America/New_York"
 
 RECAPTCHA_VERIFY_URL='https://www.google.com/recaptcha/api/siteverify'
 RECAPTCHA_SITE_KEY=os.environ.get('RECAPTCHA_SITE_KEY')


### PR DESCRIPTION
Timezone support is turned on in django, and dates are stored with timezone information (all good news). But, the timezone is explicitly configured to be UTC time. This changes it to Eastern time. Times on the servers themselves appeared to be correct (not sure if ntpd is running, but I could check on that).

Thoughts about times:
 * The formats that are used throughout the site have the timezone stripped from the time. Invariably someone in a different timezone is going to visit the site, and get confused by the times listed.
 * Given that MyHPOM will only be used on the Eastern timezone this probably isn't an issue?