### PR TITLE
[#159] Show Abstract (Notes) and Subject fields without content

### DIFF
--- a/theme/templates/resource-landing-page/abstract.html
+++ b/theme/templates/resource-landing-page/abstract.html
@@ -4,6 +4,16 @@
             <h3>Abstract</h3>
             <span class="abstract">{{ abstract|urlize|linebreaks }}</span>
         </div>
+    {% else %}
+    <div class="col-xs-12">
+        <h3>Notes</h3>
+        <hr>
+        <div class="alert alert-info" role="alert">
+            <span class="glyphicon glyphicon-question-sign"></span>
+            <small> Click on the edit button ( <span class="glyphicon glyphicon-pencil"></span> ) above to add notes to this resource.</small>
+        </div>
+        <br>
+    </div>
     {% endif %}
 {% else %}
     <div class="col-xs-12 content-block">

--- a/theme/templates/resource-landing-page/subject.html
+++ b/theme/templates/resource-landing-page/subject.html
@@ -11,6 +11,16 @@
             </ul>
         </div>
     </div>
+    {% else %}
+    <div class="col-xs-12">
+        <h3>Subject</h3>
+        <hr>
+        <div class="alert  alert-info" role="alert">
+            <span class="glyphicon glyphicon-question-sign"></span>
+            <small> Click on the edit button ( <span class="glyphicon glyphicon-pencil"></span> ) above to add keywords this resource.</small>
+        </div>
+        <br>
+    </div>
     {% endif %}
 {% else %}
     <div class="col-sm-12 content-block">


### PR DESCRIPTION
This PR tackles the issues that were run into by removing the title-section warnings in #150.  For the reason that the Abstract (in the future called Notes) is no longer going to be required to Publish, the warning will have to be removed.  There would be no indication that the two sections, Notes and Subject existed when first coming to the document. 

This PR does two things:
1) It exposes those fields when you come to visit your document even when there is no content for those sections.

2) It gives you an informational alert which prompts the user to click the edit button to see add content to each of those sections.      