### PR TITLE
Ensure that node_modules exist before compiling scss (MH-23)

### DIFF
--- a/hsctl
+++ b/hsctl
@@ -351,8 +351,7 @@ rebuild_hs() {
     if [ "${USE_NGINX}" = true ]; then
         start_nginx;
     fi
-    # compile the CSS before running compilescss or the included files won't be
-    # found:
+    # Collect CSS before running compilescss or the included files won't be found:
     echo "  - docker exec -u hydro-service hydroshare python manage.py collectstatic -v0 --noinput"
     docker exec -u hydro-service hydroshare python manage.py collectstatic -v0 --noinput
     echo "  - docker exec -u hydro-service hydroshare python manage.py compilescss"

--- a/hsctl
+++ b/hsctl
@@ -351,6 +351,10 @@ rebuild_hs() {
     if [ "${USE_NGINX}" = true ]; then
         start_nginx;
     fi
+    # compile the CSS before running compilescss or the included files won't be
+    # found:
+    echo "  - docker exec -u hydro-service hydroshare python manage.py collectstatic -v0 --noinput"
+    docker exec -u hydro-service hydroshare python manage.py collectstatic -v0 --noinput
     echo "  - docker exec -u hydro-service hydroshare python manage.py compilescss"
     docker exec -u hydro-service hydroshare python manage.py compilescss
     echo "  - docker exec -u hydro-service hydroshare python manage.py collectstatic -v0 --noinput"


### PR DESCRIPTION
When I first deployed I saw this exception in the logs (and no complied CSS):

```
WARNINGS:
hs_tracking.Visitor.user: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
     HINT: ForeignKey(unique=True) is usually better served by a OneToOneField.
security.PasswordExpiry.user: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
     HINT: ForeignKey(unique=True) is usually better served by a OneToOneField.
............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python2.7/site-packages/sass_processor/management/commands/compilescss.py", line 160, in handle
    self.parse_template(template_name)
  File "/usr/local/lib/python2.7/site-packages/sass_processor/management/commands/compilescss.py", line 271, in parse_template
self.compile_sass(sass_filename, node.path)
  File "/usr/local/lib/python2.7/site-packages/sass_processor/management/commands/compilescss.py", line 286, in compile_sass
    content = sass.compile(**compile_kwargs)
  File "/usr/local/lib/python2.7/site-packages/sass.py", line 659, in compile
    raise CompileError(v)
sass.CompileError: Error: File to import not found or unreadable: hydroshare/static/myhpom/bootstrap/scss/bootstrap.scss.
        on line 1 of myhpom/static/myhpom/myhpom.scss
>> @import "hydroshare/static/myhpom/bootstrap/scss/bootstrap.scss";
```