### PR TITLE
[MH-91] base template for upload steps

### DIFF
--- a/myhpom/static/astrum/components/uploadWidget/base/description.md
+++ b/myhpom/static/astrum/components/uploadWidget/base/description.md
@@ -1,0 +1,1 @@
+The base template for the uploader widget.

--- a/myhpom/static/astrum/components/uploadWidget/base/markup.html
+++ b/myhpom/static/astrum/components/uploadWidget/base/markup.html
@@ -1,0 +1,30 @@
+<div class="advance-directive-widget small" id="advance-directive-widget">
+    <ul class="advance-directive-widget__breadcrumbs">
+        <li class="advance-directive-widget__breadcrumb-item">
+            Select Document
+        </li>
+        <li class="advance-directive-widget__breadcrumb-item">
+            Submit
+        </li>
+        <li class="advance-directive-widget__breadcrumb-item">
+            Confirmation
+        </li>
+    </ul>
+
+    <div class="advance-directive-widget__body">
+
+        <h3 class="h6">
+            Requirements for Advance Directive:
+        </h3>
+
+        <p>
+            lorem ipsum dolor sit amet consectetur adipisicing elit
+        </p>
+        <p>
+            lorem ipsum dolor sit amet consectetur adipisicing elit sed do eiusmod tempor
+        </p>
+        <p>
+            lorem ipsum dolor sit amet consectetur
+        </p>
+    </div>
+</div>

--- a/myhpom/static/astrum/data.json
+++ b/myhpom/static/astrum/data.json
@@ -31,7 +31,8 @@
     },
     "assets": {
         "css": [
-            "/static/myhpom/myhpom.css"
+            "/static/myhpom/myhpom.css",
+            "/static/myhpom/open-iconic/font/css/open-iconic-bootstrap.css"
         ],
         "js": [
             "/static/myhpom/jquery/dist/jquery.min.js",
@@ -70,6 +71,18 @@
                     "group": "buttons",
                     "name": "cta-header",
                     "title": "Call to Action button in header",
+                    "width": "half"
+                }
+            ]
+        },
+        {
+            "name": "uploadWidget",
+            "title": "Upload Widget",
+            "components": [
+                {
+                    "group": "uploadWidget",
+                    "name": "base",
+                    "title": "Base upload widget template",
                     "width": "half"
                 }
             ]

--- a/myhpom/static/myhpom/include/_upload_widget.scss
+++ b/myhpom/static/myhpom/include/_upload_widget.scss
@@ -1,0 +1,48 @@
+.advance-directive-widget {
+    background-color: white;
+    border: 1px solid black;
+}
+
+.advance-directive-widget__breadcrumbs {
+    border-bottom: 1px solid black;
+    margin-bottom: 0;
+    padding: 1rem;
+    list-style: none;
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: center;
+
+    @include media-breakpoint-down(md) {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    @include media-breakpoint-down(sm) {
+        flex-direction: row;
+        align-items: center;
+    }
+}
+
+.advance-directive-widget__breadcrumb-item {
+    display: inline-flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    font-size: 80%;
+
+    &:not(:first-child)::before {
+        font-family: 'Icons';
+        font-size: 80%;
+        line-height: 75%;
+        content:'\e036';
+        display: inline-block;
+        margin: 0 0.35rem;
+    }
+
+    @include media-breakpoint-down(md) {
+        font-size: 100%;
+    }
+}
+
+.advance-directive-widget__body {
+    padding: 2rem;
+}

--- a/myhpom/static/myhpom/include/_upload_widget.scss
+++ b/myhpom/static/myhpom/include/_upload_widget.scss
@@ -41,6 +41,10 @@
     @include media-breakpoint-down(md) {
         font-size: 100%;
     }
+
+    @include media-breakpoint-up(xl) {
+        font-size: 100%;
+    }
 }
 
 .advance-directive-widget__body {

--- a/myhpom/static/myhpom/include/_upload_widget.scss
+++ b/myhpom/static/myhpom/include/_upload_widget.scss
@@ -11,23 +11,12 @@
     display: flex;
     flex-wrap: nowrap;
     align-items: center;
-
-    @include media-breakpoint-down(md) {
-        flex-direction: column;
-        align-items: flex-start;
-    }
-
-    @include media-breakpoint-down(sm) {
-        flex-direction: row;
-        align-items: center;
-    }
 }
 
 .advance-directive-widget__breadcrumb-item {
     display: inline-flex;
     flex-wrap: nowrap;
     align-items: center;
-    font-size: 80%;
 
     &:not(:first-child)::before {
         font-family: 'Icons';
@@ -36,14 +25,6 @@
         content:'\e036';
         display: inline-block;
         margin: 0 0.35rem;
-    }
-
-    @include media-breakpoint-down(md) {
-        font-size: 100%;
-    }
-
-    @include media-breakpoint-up(xl) {
-        font-size: 100%;
     }
 }
 

--- a/myhpom/static/myhpom/myhpom.scss
+++ b/myhpom/static/myhpom/myhpom.scss
@@ -4,6 +4,7 @@
 @import "myhpom/static/myhpom/include/footer";
 @import "myhpom/static/myhpom/include/forms";
 @import "myhpom/static/myhpom/include/modal";
+@import "myhpom/static/myhpom/include/upload_widget";
 
 @import "myhpom/static/myhpom/page/dashboard";
 @import "myhpom/static/myhpom/page/signup";

--- a/myhpom/templates/myhpom/base.html
+++ b/myhpom/templates/myhpom/base.html
@@ -9,6 +9,7 @@
         <script type="text/javascript" src="{% static "myhpom/popper.js/dist/umd/popper.min.js" %}"></script>
         <script type="text/javascript" src="{% static "myhpom/bootstrap/dist/js/bootstrap.min.js" %}"></script>
         <link href="{% sass_src 'myhpom/myhpom.scss' %}" rel="stylesheet" type="text/css" />
+        <link href="{% static 'myhpom/open-iconic/font/css/open-iconic-bootstrap.css' %}" rel="stylesheet" />
 
         <title>{% block title %}My Health Peace Of Mind{% endblock title %}</title>
     </head>

--- a/myhpom/templates/myhpom/dashboard.html
+++ b/myhpom/templates/myhpom/dashboard.html
@@ -81,7 +81,13 @@
                 {% lorem 6 w %}
             </p>
 
-            <div class="advance-directive-widget small">
+            <div class="advance-directive-widget small" id="advance-directive-widget">
+                {% comment %}
+                The following include is for demonstration purposes only.
+                This element will be selected via `$('#advance-directive-widget')`
+                and filled in with content from the various AJAX calls that
+                take the user through the steps in the upload process.
+                {% endcomment %}
                 {% include 'myhpom/includes/upload_base.html' %}
             </div>
         </section>

--- a/myhpom/templates/myhpom/dashboard.html
+++ b/myhpom/templates/myhpom/dashboard.html
@@ -18,7 +18,7 @@
     </div>
 </div>
 <div class="row">
-    <div class="col-md-8 dashboard-main">
+    <div class="col-md-6 col-lg-7 dashboard-main">
         <hr/>
 
         <section class="dashboard__section dashboard-profile-information">
@@ -71,7 +71,7 @@
             </div>
         </section>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-6 col-lg-5">
         <section class="bg-light dashboard-sidebar">
             <h2 class="h6 dashboard__section-title dashboard-sidebar__title">
                 My advance directive

--- a/myhpom/templates/myhpom/dashboard.html
+++ b/myhpom/templates/myhpom/dashboard.html
@@ -80,6 +80,10 @@
             <p class="small">
                 {% lorem 6 w %}
             </p>
+
+            <div class="advance-directive-widget small">
+                {% include 'myhpom/includes/upload_base.html' %}
+            </div>
         </section>
     </div>
 </div>

--- a/myhpom/templates/myhpom/includes/upload_base.html
+++ b/myhpom/templates/myhpom/includes/upload_base.html
@@ -1,3 +1,12 @@
+{% comment %}
+This content is rendered inside a .advance-directive-widget element,
+which is rendered inside the dashboard template to provide an
+anchor for the jQuery code to attach live-loaded HTML to.
+(This could also conceivably be appended to the container,
+but it is clearer what's happening if there is an element
+in the template that represents the entry-point.)
+{% endcomment %}
+
 <ul class="advance-directive-widget__breadcrumbs">
     <li class="advance-directive-widget__breadcrumb-item">
         Select Document
@@ -11,6 +20,9 @@
 </ul>
 
 <div class="advance-directive-widget__body">
+    {% comment %}
+    The content for the various steps in the multi-page form should go here.
+    {% endcomment %}
     <h3 class="h6">
         Requirements for Advance Directive:
     </h3>

--- a/myhpom/templates/myhpom/includes/upload_base.html
+++ b/myhpom/templates/myhpom/includes/upload_base.html
@@ -1,0 +1,27 @@
+<ul class="advance-directive-widget__breadcrumbs">
+    <li class="advance-directive-widget__breadcrumb-item">
+        Select Document
+    </li>
+    <li class="advance-directive-widget__breadcrumb-item">
+        Submit
+    </li>
+    <li class="advance-directive-widget__breadcrumb-item">
+        Confirmation
+    </li>
+</ul>
+
+<div class="advance-directive-widget__body">
+    <h3 class="h6">
+        Requirements for Advance Directive:
+    </h3>
+
+    <p>
+        {% lorem 8 w %}
+    </p>
+    <p>
+        {% lorem 12 w %}
+    </p>
+    <p>
+        {% lorem 6 w %}
+    </p>
+</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "myhpom",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bootstrap": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.2.tgz",
+      "integrity": "sha512-3bP609EdMc/8EwgGp8KgpN8HwnR4V4lZ9CTi5pImMrXNxpkw7dK1B05aMwQWpG1ZWmTLlBSN/uzkuz5GsmQNFA=="
+    },
+    "jquery": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+    },
+    "open-iconic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/open-iconic/-/open-iconic-1.1.1.tgz",
+      "integrity": "sha1-nc/Ix808Yc20ojaxo0eJTJetwMY="
+    },
+    "popper.js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
+      "integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "bootstrap": "^4.1.1",
     "jquery": "^3.3.1",
+    "open-iconic": "^1.1.1",
     "popper.js": "^1.14.3"
   }
 }


### PR DESCRIPTION
This sets up the front-end scaffolding around which the content of the upload widget's various component pages can be built out.

The only really tricky thing is the breadcrumbs, which have to be pretty shrinky to fit in the available space. I have tried to use breakpoints in a fiddly way to ensure that the breadcrumbs can take up as much space as they can (up to as much as they *want*) on various screen widths.