### PR TITLE
[MH-59] User can download template

### DIFF
--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -144,14 +144,8 @@ STATICFILES_DIRS = (
     ('styleguide', 'myhpom/static/astrum'),
 )
 
-# URL that handles the media served from MEDIA_ROOT. Make sure to use a
-# trailing slash.
-# Examples: "http://media.lawrence.com/media/", "http://example.com/media/"
-MEDIA_URL = STATIC_URL + "media/"
-
-# Absolute filesystem path to the directory that will hold user-uploaded files.
-# Example: "/home/media/media.lawrence.com/media/"
-MEDIA_ROOT = os.path.join(PROJECT_ROOT, *MEDIA_URL.strip("/").split("/"))
+MEDIA_ROOT = os.path.join(PROJECT_ROOT, 'public', 'media')
+MEDIA_URL = '/media/'
 
 # Package/module name to import the root urlpatterns from for the project.
 ROOT_URLCONF = "%s.urls" % PROJECT_DIRNAME

--- a/hydroshare/urls.py
+++ b/hydroshare/urls.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.conf.urls import include, url
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 
@@ -18,7 +19,9 @@ urlpatterns = [
 # These should be served by nginx for deployed environments,
 # presumably this is here to allow for running without DEBUG
 # on in local dev environments.
-if settings.DEBUG is False:   # if DEBUG is True it will be served automatically
+if not settings.DEBUG:   # if DEBUG is True it will be served automatically
     urlpatterns += [
         url(r'^static/(?P<path>.*)$', 'django.views.static.serve', {'document_root': settings.STATIC_ROOT}),
-]
+    ]
+else:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/myhpom/templates/myhpom/accounts/next_steps.html
+++ b/myhpom/templates/myhpom/accounts/next_steps.html
@@ -31,7 +31,7 @@
                             <div class="col-md-6 vertical-fill-box">
                                 <div class="advance-directive-block">
                                     <h5>
-                                        <a href="{{ ad_template.url }}" target="_blank">
+                                        <a href="{{ ad_template.url }}" target="_blank" rel="noopener noreferrer">
                                             Download a Template Advance Directive
                                         </a>
                                     </h5>

--- a/myhpom/templates/myhpom/accounts/next_steps.html
+++ b/myhpom/templates/myhpom/accounts/next_steps.html
@@ -31,7 +31,7 @@
                             <div class="col-md-6 vertical-fill-box">
                                 <div class="advance-directive-block">
                                     <h5>
-                                        <a href="{{ ad_template.advance_directive_template.url }}">
+                                        <a href="{{ ad_template.url }}" target="_blank">
                                             Download a Template Advance Directive
                                         </a>
                                     </h5>

--- a/nginx/config-files/hydroshare-nginx.conf
+++ b/nginx/config-files/hydroshare-nginx.conf
@@ -1,4 +1,4 @@
-# hydroshare-nginx.conf                                                         
+# hydroshare-nginx.conf
 
 server {
     listen          80;
@@ -19,7 +19,7 @@ server {
     }
 
     location /media/ {
-        alias /hydroshare/hydroshare/static/media/;
+        alias /hydroshare/hydroshare/public/media/;
     }
 
     location / {

--- a/nginx/config-files/hydroshare-ssl-nginx.conf
+++ b/nginx/config-files/hydroshare-ssl-nginx.conf
@@ -28,7 +28,7 @@ server {
     }
 
     location /media/ {
-        alias /hydroshare/hydroshare/static/media/;
+        alias /hydroshare/hydroshare/public/media/;
     }
 
     location / {


### PR DESCRIPTION
As it turns out, getting the downloading of templates working is a trivial change. I(?) just made a mistake about the path to the URL. This can be fixed and `target="_blank"` can be added.

*However*, I think there's something problematic about file storage at present, because I get a 404 when I follow this link. *Clearly the correct URL is being used*, in some sense, and so I still submit this for review knowing that the result 404s—the problem isn't with *this* code.