### PR TITLE
[MH-120] Add general method for handling non-ajax links

### DIFF
--- a/myhpom/templates/myhpom/dashboard.html
+++ b/myhpom/templates/myhpom/dashboard.html
@@ -191,7 +191,7 @@ jQuery(function ($) {
     }
 
     function handleAnchorClick() {
-        if ($(this).data('no-ajax')) {
+        if ($(this).is('[target="_blank"]') || $(this).data('no-ajax')) {
             return;
         }
         handleAjax($.ajax({

--- a/myhpom/templates/myhpom/dashboard.html
+++ b/myhpom/templates/myhpom/dashboard.html
@@ -191,7 +191,7 @@ jQuery(function ($) {
     }
 
     function handleAnchorClick() {
-        if ($(this).is('[data-toggle="modal"], .modal a')) {
+        if ($(this).data('no-ajax')) {
             return;
         }
         handleAjax($.ajax({

--- a/myhpom/templates/myhpom/upload/current_ad.html
+++ b/myhpom/templates/myhpom/upload/current_ad.html
@@ -19,13 +19,13 @@
 
 <div class="row">
     <div class="col">
-        <a class="advance-directive-widget__button--primary" href="{{ request.user.advancedirective.document.url }}" target="_blank" rel="noopener noreferrer">Download</a>
+        <a class="advance-directive-widget__button--primary" href="{{ request.user.advancedirective.document.url }}" data-no-ajax="true" target="_blank" rel="noopener noreferrer">Download</a>
     </div>
 </div>
 
 <div class="row">
     <div class="col">
-        <a class="advance-directive-widget__delete-link" href="#delete-modal" data-toggle="modal" data-target="#delete-modal">Delete document</a>
+        <a class="advance-directive-widget__delete-link" href="#delete-modal" data-no-ajax="true" data-toggle="modal" data-target="#delete-modal">Delete document</a>
     </div>
 </div>
 

--- a/myhpom/templates/myhpom/upload/current_ad.html
+++ b/myhpom/templates/myhpom/upload/current_ad.html
@@ -19,7 +19,7 @@
 
 <div class="row">
     <div class="col">
-        <a class="advance-directive-widget__button--primary" href="{{ request.user.advancedirective.document.url }}" data-no-ajax="true" target="_blank" rel="noopener noreferrer">Download</a>
+        <a class="advance-directive-widget__button--primary" href="{{ request.user.advancedirective.document.url }}" target="_blank" rel="noopener noreferrer">Download</a>
     </div>
 </div>
 

--- a/myhpom/templates/myhpom/upload/index.html
+++ b/myhpom/templates/myhpom/upload/index.html
@@ -21,7 +21,7 @@
 
 {% if request.user.userdetails.state.advance_directive_template %}
 <p>
-    <a class="advance-directive-widget__button--secondary" href="{{ request.user.userdetails.state.advance_directive_template.url }}" data-no-ajax="true" target="_blank">
+    <a class="advance-directive-widget__button--secondary" href="{{ request.user.userdetails.state.advance_directive_template.url }}" target="_blank">
         Download a Template
     </a>
 </p>

--- a/myhpom/templates/myhpom/upload/index.html
+++ b/myhpom/templates/myhpom/upload/index.html
@@ -21,11 +21,10 @@
 
 {% if request.user.userdetails.state.advance_directive_template %}
 <p>
-    <a class="advance-directive-widget__button--secondary" href="{{ request.user.userdetails.state.advance_directive_template.url }}" target="_blank">
+    <a class="advance-directive-widget__button--secondary" href="{{ request.user.userdetails.state.advance_directive_template.url }}" data-no-ajax="true" target="_blank">
         Download a Template
     </a>
 </p>
 {% endif %}
 
 {% endblock widget_body %}
-


### PR DESCRIPTION
We need to ensure that those links that pop open a new tab or otherwise do not involve AJAX behavior do not trigger that behavior.

This checks whether a link is `target="_blank"` or `data-no-ajax="true"`, and if so, it ignores it for AJAX link purposes.