### PR TITLE
[MH-129] Save original filename of AD

### DIFF
--- a/myhpom/forms/upload_requirements.py
+++ b/myhpom/forms/upload_requirements.py
@@ -8,7 +8,7 @@ class UploadRequirementsForm(forms.ModelForm):
 
     class Meta:
         model = AdvanceDirective
-        fields = ['valid_date', 'document']
+        fields = ['valid_date', 'document', 'original_filename']
 
     def clean_document(self):
         document = self.cleaned_data['document']
@@ -26,6 +26,13 @@ class UploadRequirementsForm(forms.ModelForm):
             raise forms.ValidationError(errors)
 
         return document
+
+    def clean(self):
+        data = self.cleaned_data
+        if 'document' in data:
+            data['original_filename'] = data['document'].name
+
+        return data
 
 
 class SharingForm(forms.ModelForm):

--- a/myhpom/migrations/0014_advancedirective_original_filename.py
+++ b/myhpom/migrations/0014_advancedirective_original_filename.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('myhpom', '0013_auto_20180720_0942'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='advancedirective',
+            name='original_filename',
+            field=models.CharField(max_length=512, blank=True),
+        ),
+    ]

--- a/myhpom/models/document.py
+++ b/myhpom/models/document.py
@@ -14,6 +14,10 @@ class AdvanceDirective(models.Model):
         upload_to='myhpom/advance_directives',
         help_text='The document representing this user\'s Advance Directive.',
     )
+    original_filename = models.CharField(
+        max_length=512,
+        blank=True,
+    )
     valid_date = models.DateField(
         help_text='Date that this document is legally valid.',
         validators=[validate_date_in_past],
@@ -24,4 +28,4 @@ class AdvanceDirective(models.Model):
 
     @property
     def filename(self):
-        return os.path.basename(self.document.name)
+        return self.original_filename or os.path.basename(self.document.name)


### PR DESCRIPTION
The fact that Django's `Storage` adds random junk to the uploaded file's name to avoid name clashes is a known source of annoyance.

Of all the various approaches to the problem, I like best the one where we have a separate model representing file metadata, e.g. upload time and, here, original filename. Luckily, we already *have* such a metadata model, namely `AdvanceDirective`, so we can just augment it with an `original_filename` field.

AFAIC it only really makes sense to generate the `original_filename` value at the point of upload, which is to say within the `UploadRequirementsForm`. Hence I've also added `original_filename` as a field to that form and added `clean` logic to copy over the `document.name` value (since `clean` is where we represent interdependencies between form fields).