### PR TITLE
Setup errors to go to admins & temporary fix to broken proxy.

### DIFF
--- a/hydroshare/local_settings.py
+++ b/hydroshare/local_settings.py
@@ -10,6 +10,8 @@ from kombu.common import Broadcast
 
 DEBUG = os.environ.get('DEBUG') == 'true'
 
+ADMINS = [('MMH Team', 'mmh-team@caktusgroup.com')]
+
 # These secret keys are used by the pg.myhpomdevelopment.sql development dump,
 # if you change these, you will not be able to login with users setup in the
 # dump:

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -266,6 +266,11 @@ PASSWORD_RESET_TIMEOUT_DAYS = 1
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse',
+        }
+    },
     'formatters': {
         'verbose': {
             'format' : "[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s",
@@ -303,6 +308,7 @@ LOGGING = {
         },
         'mail_admins': {
             'level': 'ERROR',
+            'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler',
             'include_html': True,
         },

--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -301,6 +301,11 @@ LOGGING = {
             'maxBytes': 1024*1024*15, # 15MB
             'backupCount': 10,
         },
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler',
+            'include_html': True,
+        },
     },
     'loggers': {
         'django': {
@@ -315,7 +320,7 @@ LOGGING = {
         },
         # Catch-all logger for HydroShare apps
         '': {
-            'handlers': ['hydrosharelog'],
+            'handlers': ['hydrosharelog', 'mail_admins'],
             'propagate': False,
             'level': 'DEBUG'
         },
@@ -323,7 +328,9 @@ LOGGING = {
 }
 
 # inform django that a reverse proxy sever (nginx) is handling ssl/https for it
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+# TODO replace with the standard header values once RENCI resolves the issue:
+# SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SECURE_PROXY_SSL_HEADER = ('SERVER_NAME', 'myhpom.renci.org')
 
 X_FRAME_OPTIONS = "deny"
 


### PR DESCRIPTION
This includes a temporary setting change to SECURE_PROXY_SSL_HEADER so
that all reverse() calls will return https URLs.