### PR TITLE
[MH-145] Switching method of parsing dates to use Moment

### DIFF
--- a/myhpom/templates/myhpom/upload/requirements.html
+++ b/myhpom/templates/myhpom/upload/requirements.html
@@ -94,17 +94,17 @@ jQuery(function ($) {
     var $submitButton = $('#id_button_submit');
     var $directiveDateInput = $('#id_valid_date');
     var $inputSelectFile = $("#id_document");
-    var NOW = new Date();
+    var NOW = moment();
 
     // Currently the help links on this page aren't intended to do anything (until behavior is defined):
     $(".upload-requirements__help--right").click(function (event) { event.preventDefault(); });
     $(".upload-requirements-link__item a").click(function (event) { event.preventDefault(); });
 
     function submitButtonEnableDisable () {
-        var $directiveDate = new Date($directiveDateInput.val() + " 00:00:00");
+        var directiveDate = moment($directiveDateInput.val());
         if ($('.upload-requirements__checkbox:checked').length === $requirements.length
             && $directiveDateInput.combodate('getValue').trim() !== ''
-            && $directiveDate <= NOW
+            && directiveDate.isSameOrBefore(NOW)
             && $inputSelectFile.val().trim() !== ''
             && $inputSelectFile[0].files[0].size < {{ MAX_AD_SIZE }}
         ) {
@@ -132,8 +132,8 @@ jQuery(function ($) {
                 $("#id_valid_date_errors").html("Please enter the valid date of your document.");
             }
         } else {
-            var $directiveDate = new Date($directiveDateInput.val() + " 00:00:00");
-            if ($directiveDate > NOW) {
+            var directiveDate = moment($directiveDateInput.val());
+            if (directiveDate.isAfter(NOW)) {
                 $("#id_valid_date_div select").addClass("upload-requirement__select--invalid");
                 $("#id_valid_date_errors").html("Please enter a valid date on or before today.");
             } else {


### PR DESCRIPTION
The issue with being unable to upload the AD because of a permanently disabled upload button was being caused by the `submitButtonEnableDisable` function consistently flunking the form because the parsing of the directive date input was, on some browsers, not working right.

To abstract away from the inconsistent way browsers use the `Date` object, we can use our Moment.js dependency to do the date parsing and comparison for us. Instead of `new Date(/*...*/)`, just `moment(/*...*/)`; instead of `fooDate <= barDate`, `fooDate.isSameOrBefore(barDate)`.

I speculate that, as Gerald hoped, MH-150 will also be fixed by this.