### PR TITLE
[mh-13] add condition and link for I am / I am not organ donor, with …

### DIFF
--- a/myhpom/templates/myhpom/dashboard.html
+++ b/myhpom/templates/myhpom/dashboard.html
@@ -57,14 +57,20 @@
                         <img class="dashboard-profile-information__organ-icon" src="{% static 'myhpom/img/donor/icon-donor@3x.png' %}" alt="">
                     </div>
                     <div>
+                        {% if request.user.userdetails.is_organ_donor %}
+                        <div class="dashboard-profile-information__organ-donor-status-info">
+                            <span class="h5 dashboard-profile-information__status">I am an organ donor.</span>
+                        </div>
+                        {% else %}
                         <div class="dashboard-profile-information__organ-donor-status-info">
                             <span class="h5 dashboard-profile-information__status">I am not an organ donor.</span>
                         </div>
                         <div>
-                            <a href="/" class="dashboard-profile-information__organ-donor-link">
+                            <a href="http://donatelifenc.org/Register" alt="Donate Life" class="dashboard-profile-information__organ-donor-link">
                                 Learn how you can be a donor.
                             </a>
                         </div>
+                        {% endif %}
                     </div>
                     <div class="h6 dashboard-profile-information__organ-donor-edit-link">
                         <a href="{% url 'myhpom:edit_profile' %}" class="small"><span class="oi oi-pencil"></span> Edit</a>

--- a/myhpom/tests/test_dashboard_view.py
+++ b/myhpom/tests/test_dashboard_view.py
@@ -40,3 +40,25 @@ class DashboardTestCase(TestCase):
         self.assertTemplateUsed('myhpom/dashboard.html')
         self.assertTemplateUsed('myhpom/upload/current_ad.html')
         self.assertIsNotNone(response.context['advancedirective'])
+
+    def test_user_is_organ_donor(self):
+        """
+        + A user who is an organ donor should see "I am an organ donor" and no link
+        + A user who is not an organ donor should see "I am not an organ donor" and a link
+        """
+        user = UserFactory()
+        user.set_password('password')
+        user.save()
+        self.assertTrue(self.client.login(username=user.username, password='password'))
+
+        user.userdetails.is_organ_donor = False
+        user.userdetails.save()
+        response = self.client.get(self.url)
+        self.assertIn('I am not an organ donor', response.content)
+        self.assertIn('Learn how you can be a donor.', response.content)
+
+        user.userdetails.is_organ_donor = True
+        user.userdetails.save()
+        response = self.client.get(self.url)
+        self.assertIn('I am an organ donor', response.content)
+        self.assertNotIn('Learn how you can be a donor.', response.content)


### PR DESCRIPTION
This PR only changes the dashboard -- what is displayed for the organ donor status now reflects what is stored in the profile (user.userdetails.is_organ_donor). The setting of that flag is already active in the edit_profile page, and I don't think we are asking for anything beyond that here. 

AC: 
As a user, I want to choose whether or not I am organ donor, so that this important piece of information is recorded

* User can select whether or not they are an organ donor with yes or no options
* User can click on a link that says "Learn how you can be a donor" if the user donor selection is No (which is the default)
** That link goes to [http://donatelifenc.org/Register] (alt text “Donate Life”)
