### PR TITLE
Mh 178  update network validation

### DIFF
--- a/myhpom/forms/choose_network.py
+++ b/myhpom/forms/choose_network.py
@@ -12,14 +12,15 @@ class ChooseNetworkForm(forms.ModelForm):
         custom_provider = cleaned_data.get('custom_provider')
         health_network = cleaned_data.get('health_network')
 
+        # if state has health networks, one and only one health_network or custom_provider
         if self.instance and self.instance.state and self.instance.state.healthnetwork_set.exists():
             if (not custom_provider and not health_network) or (custom_provider and health_network):
                 raise forms.ValidationError(
                     'Please either choose a network or enter a custom network.'
                 )
-        else:
-            if not custom_provider:
-                raise forms.ValidationError('Please enter a custom network.')
+        # if state has no health networks, there must be a custom_provider
+        elif not custom_provider:
+            raise forms.ValidationError('Please enter a custom network.')
 
         return cleaned_data
 

--- a/myhpom/forms/choose_network.py
+++ b/myhpom/forms/choose_network.py
@@ -1,9 +1,6 @@
 from django import forms
 from django.utils import timezone
-from myhpom.models import (
-    HealthNetwork,
-    UserDetails,
-)
+from myhpom.models import HealthNetwork, UserDetails
 
 
 class ChooseNetworkForm(forms.ModelForm):
@@ -15,10 +12,16 @@ class ChooseNetworkForm(forms.ModelForm):
         custom_provider = cleaned_data.get('custom_provider')
         health_network = cleaned_data.get('health_network')
 
-        if ((not custom_provider) and (not health_network)) or (custom_provider and health_network):
-            raise forms.ValidationError(
-                'Please either choose a network or enter a custom network.'
-            )
+        if self.instance and self.instance.state and self.instance.state.healthnetwork_set.exists():
+            if ((not custom_provider) and (not health_network)) or (
+                custom_provider and health_network
+            ):
+                raise forms.ValidationError(
+                    'Please either choose a network or enter a custom network.'
+                )
+        else:
+            if not custom_provider:
+                raise forms.ValidationError('Please enter a custom network.')
 
         return cleaned_data
 
@@ -28,9 +31,7 @@ class ChooseNetworkForm(forms.ModelForm):
             try:
                 return HealthNetwork.objects.get(id=data)
             except HealthNetwork.DoesNotExist:
-                raise forms.ValidationError(
-                    'Selected health network does not exist.'
-                )
+                raise forms.ValidationError('Selected health network does not exist.')
         return None
 
     def save(self, *args, **kwargs):
@@ -48,7 +49,4 @@ class ChooseNetworkForm(forms.ModelForm):
 
     class Meta:
         model = UserDetails
-        fields = [
-            'health_network',
-            'custom_provider',
-        ]
+        fields = ['health_network', 'custom_provider']

--- a/myhpom/forms/choose_network.py
+++ b/myhpom/forms/choose_network.py
@@ -13,9 +13,7 @@ class ChooseNetworkForm(forms.ModelForm):
         health_network = cleaned_data.get('health_network')
 
         if self.instance and self.instance.state and self.instance.state.healthnetwork_set.exists():
-            if ((not custom_provider) and (not health_network)) or (
-                custom_provider and health_network
-            ):
+            if (not custom_provider and not health_network) or (custom_provider and health_network):
                 raise forms.ValidationError(
                     'Please either choose a network or enter a custom network.'
                 )
@@ -26,10 +24,10 @@ class ChooseNetworkForm(forms.ModelForm):
         return cleaned_data
 
     def clean_health_network(self):
-        data = self.cleaned_data['health_network']
-        if data:
+        health_network_id = self.cleaned_data['health_network']
+        if health_network_id:
             try:
-                return HealthNetwork.objects.get(id=data)
+                return HealthNetwork.objects.get(id=health_network_id)
             except HealthNetwork.DoesNotExist:
                 raise forms.ValidationError('Selected health network does not exist.')
         return None

--- a/myhpom/forms/choose_network.py
+++ b/myhpom/forms/choose_network.py
@@ -1,9 +1,20 @@
 from django import forms
 from django.utils import timezone
-from myhpom.models import (
-    HealthNetwork,
-    UserDetails,
-)
+from myhpom.models import HealthNetwork, UserDetails
+
+
+class ChooseNetworkNoADTemplateForm(forms.ModelForm):
+    custom_provider = forms.CharField(max_length=1024)
+
+    class Meta:
+        model = UserDetails
+        fields = ['custom_provider']
+
+    def save(self, *args, **kwargs):
+        saved = super(ChooseNetworkNoADTemplateForm, self).save(*args, **kwargs)
+        self.instance.health_network_updated = timezone.now()
+        self.instance.save()
+        return saved
 
 
 class ChooseNetworkForm(forms.ModelForm):
@@ -16,9 +27,7 @@ class ChooseNetworkForm(forms.ModelForm):
         health_network = cleaned_data.get('health_network')
 
         if ((not custom_provider) and (not health_network)) or (custom_provider and health_network):
-            raise forms.ValidationError(
-                'Please either choose a network or enter a custom network.'
-            )
+            raise forms.ValidationError('Please either choose a network or enter a custom network.')
 
         return cleaned_data
 
@@ -28,9 +37,7 @@ class ChooseNetworkForm(forms.ModelForm):
             try:
                 return HealthNetwork.objects.get(id=data)
             except HealthNetwork.DoesNotExist:
-                raise forms.ValidationError(
-                    'Selected health network does not exist.'
-                )
+                raise forms.ValidationError('Selected health network does not exist.')
         return None
 
     def save(self, *args, **kwargs):
@@ -48,7 +55,4 @@ class ChooseNetworkForm(forms.ModelForm):
 
     class Meta:
         model = UserDetails
-        fields = [
-            'health_network',
-            'custom_provider',
-        ]
+        fields = ['health_network', 'custom_provider']

--- a/myhpom/forms/choose_network.py
+++ b/myhpom/forms/choose_network.py
@@ -1,20 +1,9 @@
 from django import forms
 from django.utils import timezone
-from myhpom.models import HealthNetwork, UserDetails
-
-
-class ChooseNetworkNoADTemplateForm(forms.ModelForm):
-    custom_provider = forms.CharField(max_length=1024)
-
-    class Meta:
-        model = UserDetails
-        fields = ['custom_provider']
-
-    def save(self, *args, **kwargs):
-        saved = super(ChooseNetworkNoADTemplateForm, self).save(*args, **kwargs)
-        self.instance.health_network_updated = timezone.now()
-        self.instance.save()
-        return saved
+from myhpom.models import (
+    HealthNetwork,
+    UserDetails,
+)
 
 
 class ChooseNetworkForm(forms.ModelForm):
@@ -27,7 +16,9 @@ class ChooseNetworkForm(forms.ModelForm):
         health_network = cleaned_data.get('health_network')
 
         if ((not custom_provider) and (not health_network)) or (custom_provider and health_network):
-            raise forms.ValidationError('Please either choose a network or enter a custom network.')
+            raise forms.ValidationError(
+                'Please either choose a network or enter a custom network.'
+            )
 
         return cleaned_data
 
@@ -37,7 +28,9 @@ class ChooseNetworkForm(forms.ModelForm):
             try:
                 return HealthNetwork.objects.get(id=data)
             except HealthNetwork.DoesNotExist:
-                raise forms.ValidationError('Selected health network does not exist.')
+                raise forms.ValidationError(
+                    'Selected health network does not exist.'
+                )
         return None
 
     def save(self, *args, **kwargs):
@@ -55,4 +48,7 @@ class ChooseNetworkForm(forms.ModelForm):
 
     class Meta:
         model = UserDetails
-        fields = ['health_network', 'custom_provider']
+        fields = [
+            'health_network',
+            'custom_provider',
+        ]

--- a/myhpom/tests/test_choose_network_view.py
+++ b/myhpom/tests/test_choose_network_view.py
@@ -1,7 +1,8 @@
 from django.core.urlresolvers import reverse
-from django.test import Client, TestCase
+from django.test import TestCase
 from myhpom import models
 from myhpom.models.user import User
+from myhpom.tests.factories import UserFactory
 
 
 class ChooseNetworkTestCase(TestCase):
@@ -17,15 +18,13 @@ class ChooseNetworkTestCase(TestCase):
     """
 
     def setUp(self):
-        user_data = dict(email="Ab@example.com", password="Abbbbb1@", first_name='A', last_name='b')
-        self.user = User(**user_data)
-        self.user.set_password(user_data['password'])
+        self.user = UserFactory()
+        self.user.set_password('password')
         self.user.save()
-        self.client = Client()
-        self.client.login(username=user_data['email'], password=user_data['password'])
+        self.client.login(username=self.user.username, password='password')
         self.url = reverse('myhpom:choose_network')
-        state = models.State.objects.get(name="NC")
-        userdetails = models.UserDetails.objects.create(user=self.user, state=state)
+        self.user.userdetails.state = models.State.objects.get(name="NC")
+        self.user.userdetails.save()
 
     def test_GET_supported_state(self):
         """GET with supported state views this page
@@ -59,34 +58,26 @@ class ChooseNetworkTestCase(TestCase):
         """
         state = self.user.userdetails.state
         health_network = models.HealthNetwork.objects.filter(state=state, priority=0)[0]
-        form_data = {
-            "custom_provider": "Foo Bar Baz",
-            "health_network": health_network.id
-        }
+        form_data = {"custom_provider": "Foo Bar Baz", "health_network": health_network.id}
         response = self.client.post(self.url, data=form_data)
         form = response.context['form']
         self.assertIsNotNone(form.errors)
         self.assertIsNotNone(form.non_field_errors())
         self.assertIn(
-            'Please either choose a network or enter a custom network.',
-            form.non_field_errors(),
+            'Please either choose a network or enter a custom network.', form.non_field_errors()
         )
 
     def test_POST_neither_provider_type_fails(self):
         """
         POST without either type of health network data will be rejected.
         """
-        form_data = {
-            "custom_provider": '',
-            "health_network": None,
-        }
+        form_data = {"custom_provider": '', "health_network": None}
         response = self.client.post(self.url, data=form_data)
         form = response.context['form']
         self.assertIsNotNone(form.errors)
         self.assertIsNotNone(form.non_field_errors())
         self.assertIn(
-            'Please either choose a network or enter a custom network.',
-            form.non_field_errors(),
+            'Please either choose a network or enter a custom network.', form.non_field_errors()
         )
 
     def test_POST_health_network(self):

--- a/myhpom/views/accounts.py
+++ b/myhpom/views/accounts.py
@@ -3,17 +3,16 @@ from django.core.urlresolvers import reverse
 from django.views.decorators.http import require_GET
 from django.contrib.auth.decorators import login_required
 
-from myhpom.forms.choose_network import ChooseNetworkForm
+from myhpom.forms.choose_network import ChooseNetworkNoADTemplateForm
 
 
 @login_required
 def next_steps(request):
     state = request.user.userdetails.state
-
-    form = ChooseNetworkForm(instance=request.user.userdetails)
+    form = ChooseNetworkNoADTemplateForm(instance=request.user.userdetails)
 
     if request.POST:
-        form = ChooseNetworkForm(request.POST, instance=request.user.userdetails)
+        form = ChooseNetworkNoADTemplateForm(request.POST, instance=request.user.userdetails)
         if form.is_valid():
             form.save()
             return redirect("myhpom:dashboard")

--- a/myhpom/views/accounts.py
+++ b/myhpom/views/accounts.py
@@ -3,16 +3,17 @@ from django.core.urlresolvers import reverse
 from django.views.decorators.http import require_GET
 from django.contrib.auth.decorators import login_required
 
-from myhpom.forms.choose_network import ChooseNetworkNoADTemplateForm
+from myhpom.forms.choose_network import ChooseNetworkForm
 
 
 @login_required
 def next_steps(request):
     state = request.user.userdetails.state
-    form = ChooseNetworkNoADTemplateForm(instance=request.user.userdetails)
+
+    form = ChooseNetworkForm(instance=request.user.userdetails)
 
     if request.POST:
-        form = ChooseNetworkNoADTemplateForm(request.POST, instance=request.user.userdetails)
+        form = ChooseNetworkForm(request.POST, instance=request.user.userdetails)
         if form.is_valid():
             form.save()
             return redirect("myhpom:dashboard")

--- a/myhpom/views/choose_network.py
+++ b/myhpom/views/choose_network.py
@@ -16,6 +16,7 @@ def choose_network(request, is_update=False):
     """
     user_details = request.user.userdetails
     state = user_details.state
+    supported_state = state.healthnetwork_set.exists()
     form = ChooseNetworkForm(instance=request.user.userdetails)
 
     if request.POST:
@@ -48,6 +49,6 @@ def choose_network(request, is_update=False):
         "PRIORITY": PRIORITY,
         "form": form,
         "is_update": is_update,
-        "supported_state": state.healthnetwork_set.exists(),
+        "supported_state": supported_state,
     }
     return render(request, 'myhpom/accounts/choose_network.html', context=context)


### PR DESCRIPTION
What started as a small validation message change led to exploring whether we needed two ChooseNetwork forms or one. I opt for one form with logic to handle whether the state in question has health_networks or not; if not, the validation message is shorter. 

The heart of the changes are in two places:

1. The validation logic in ChooseNetworkForm.clean()
2. Added tests in test_update_network_view (which is where these cases are hit) 

I also made a number of code cleanup changes that don't really affect anything.

It might be worthwhile to refactor the current next_steps logic, but I didn't attempt that as part of this bugfix.