### PR TITLE
[mh-143-189-190] make scribble 'slug' and 'url' read only in admin, a…

### DIFF
--- a/myhpom/admin.py
+++ b/myhpom/admin.py
@@ -28,6 +28,8 @@ class StateAdmin(admin.ModelAdmin):
 
 class ScribbleAdmin(admin.ModelAdmin):
     model = Scribble
+    readonly_fields = ['slug', 'url']
+    list_display = ['slug', 'name', 'url']
 
 
 admin.site.register(State, StateAdmin)


### PR DESCRIPTION
This is a tiny little change to the scribbler admin

* MH-189: slug & url are read-only
* MH-190: name is shown in the list view (second column so that the link is always clickable, on the slug)

it didn't seem that any tests were needed since this is all config.