### PR TITLE
[MH-133] Style fixes for "select/update network" modal

### DIFF
--- a/myhpom/static/myhpom/include/_pseudo-modal.scss
+++ b/myhpom/static/myhpom/include/_pseudo-modal.scss
@@ -119,6 +119,10 @@ html [type="button"].close--link {
     font-weight: $modal-heavy-font-weight;
 }
 
+.pseudo-modal__label--subdued {
+    font-weight: normal;
+}
+
 .pseudo-modal__label--center-full {
     text-align: center;
     width: 100%;
@@ -150,4 +154,8 @@ html [type="button"].close--link {
 .pseudo-modal__skip-link {
     @extend .form-group-tos__link;
     line-height: 1;
+}
+
+.pseudo-modal__tooltip-text {
+    @include orange-link;
 }

--- a/myhpom/templates/myhpom/accounts/choose_network.html
+++ b/myhpom/templates/myhpom/accounts/choose_network.html
@@ -7,7 +7,6 @@
             {% if not is_update %}
             <div class="pb-0 modal-header pseudo-modal__header pseudo-modal__header--centered">
               <strong>Thank you for registering.&nbsp;</strong>
-              Please check your email to confirm account.
             </div>
             {% endif %}
 
@@ -19,9 +18,9 @@
 
             <div class="pt-0 modal-body pseudo-modal__body">
                 <div class="row">
-                    <div class="col-12">
-                        <small>How do I find my healthcare network?</small>
-                        <small>Why is Medicare / Medicaid not an option?</small>
+                    <div class="col-12 col--centered">
+                        <small class="mx-1 pseudo-modal__tooltip-text">How do I find my healthcare network?</small>
+                        <small class="mx-1 pseudo-modal__tooltip-text">Why is Medicare / Medicaid not an option?</small>
                     </div>
                 </div>
 
@@ -89,7 +88,7 @@
                                 {% csrf_token %}
                                 <!-- store the selected health_network id in the hidden input -->
                                 <input type="hidden" name="health_network" id="id_health_network" />
-                                <label class="pseudo-modal__label" for="id_custom_provider">{% if supported_state %}Not listed? {% endif %}Write network below:</label>
+                                <label class="pseudo-modal__label pseudo-modal__label--subdued" for="id_custom_provider">{% if supported_state %}<strong>Not listed?</strong> {% endif %}Write network below:</label>
                                 <input class="form-control pseudo-modal__input" type="text" name="custom_provider" id="id_custom_provider" />
                             </form>
                         </div>


### PR DESCRIPTION
It appears that by the time this ticket was negotiated, we want four things:

- center the tooltip text on the relevant modal
- make it orange
- remove the reference to account confirmation from the top
- unbold the second part of that "write it in" text

This does those four things.