### PR TITLE
[mh-192] update next_steps scribbles

### DIFF
--- a/myhpom/migrations/0018_scribble_data.json
+++ b/myhpom/migrations/0018_scribble_data.json
@@ -1,0 +1,15 @@
+{
+	"delete": [
+    {"slug": "next-steps-header", "url": "shared", "content": "{% lorem 24 w %}"},
+    {"slug": "next-steps-download", "url": "shared", "content": "<p>\n{% lorem 36 w %}\n</p>"},
+    {"slug": "next-steps-upload", "url": "shared", "content": "<p>\n{% lorem 36 w %}\n</p>"}
+  ],
+	"create": [
+    {"slug": "header-text", "url": "next_steps", "content": "You are joining millions across the country in owning your own health by planning for care in advance. Your next steps:"},
+    {"slug": "upload-text", "url": "next_steps", "content": "<strong class=\"next-steps__strong\">Wonderful! Is it in PDF form?</strong>\n<br/>\nScan and save your document in high resolution to upload on your Mind My Health dashboard."},
+    {"slug": "download-text", "url": "next_steps", "content": "<a class=\"advance-directive-block__template-link\" href=\"{{ ad_template.url }}\" target=\"_blank\" rel=\"noopener noreferrer\">\nDownload our free template</a>,\ndocument your desired care, and follow the\ninstructions on your Mind My Health Dashboard."},
+    {"slug": "header-text-no-template", "url": "next_steps", "content": "{% lorem 24 w %}"},
+    {"slug": "welcome-text-no-template", "url": "next_steps", "content": "<p>\n    Currently, Mind My Health serves North Carolina\n    and South Carolina.\n    <small>\n        <a href=\"{% url 'myhpom:home' %}\">\n            (Why North and South Carolina?)\n        </a>\n    </small>\n</p>\n<p>\n    However, we are continuing to grow and invite\n    you to continue building your account.\n    We will notify you as we expand into your state.\n</p>\n<p>\n    You may still store your documents with us\n    and retrieve them upon request.\n</p>"}
+
+  ]
+}

--- a/myhpom/migrations/0018_scribble_data.py
+++ b/myhpom/migrations/0018_scribble_data.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import os, json
+from django.db import migrations, models
+from scribbler.models import Scribble
+
+
+def load_scribbles_data(apps, schema_editor):
+    with open(os.path.splitext(__file__)[0] + '.json', 'r') as f:
+        scribbles_data = json.load(f)
+    for data in scribbles_data['delete']:
+        scribble = Scribble.objects.filter(slug=data['slug'], url=data['url']).first()
+        if scribble:
+            scribble.delete()
+    for data in scribbles_data['create']:
+        scribble = Scribble.objects.filter(slug=data['slug'], url=data['url']).first()
+        if not scribble:
+            Scribble.objects.create(**data)
+
+
+def unload_scribbles_data(apps, schema_editor):
+    with open(os.path.splitext(__file__)[0] + '.json', 'r') as f:
+        scribbles_data = json.load(f)
+    # reverse the above
+    for data in scribbles_data['create']:
+        scribble = Scribble.objects.filter(slug=data['slug'], url=data['url']).first()
+        if scribble:
+            scribble.delete()
+    for data in scribbles_data['delete']:
+        scribble = Scribble.objects.filter(slug=data['slug'], url=data['url']).first()
+        if not scribble:
+            Scribble.objects.create(**data)
+
+
+class Migration(migrations.Migration):
+    dependencies = [('myhpom', '0017_ad_thumbnail')]
+    operations = [migrations.RunPython(load_scribbles_data, reverse_code=unload_scribbles_data)]

--- a/myhpom/static/myhpom/page/_next_steps.scss
+++ b/myhpom/static/myhpom/page/_next_steps.scss
@@ -48,6 +48,7 @@
     @include serif;
     font-size: 125%;
     font-weight: 300;
+    margin-bottom: 1rem;
 }
 
 .next-steps__strong {

--- a/myhpom/templates/myhpom/accounts/next_steps.html
+++ b/myhpom/templates/myhpom/accounts/next_steps.html
@@ -15,7 +15,7 @@
 
             <div class="pt-1 pb-1 modal-header modal-header--subtitle modal-header--next-steps pseudo-modal__header">
                 <div class="mx-auto mb-0 pseudo-modal__header-caption-text pseudo-modal__header-caption-text--next-steps">
-                    {% scribble 'next-steps-header' 'shared' %}
+                    {% scribble 'header-text' 'next_steps' %}
                     You are joining millions across the country in owning
                     your own health by planning for care in advance.
                     Your next steps:
@@ -30,13 +30,14 @@
                             <h4 class="advance-directive-block__title">
                                 Do you already have your advance care plan?
                             </h4>
-                            <p class="next-steps__text">
-                                {% scribble 'next-steps-upload' 'shared' %}
+                            <div class="next-steps__text">
+                                {% scribble 'upload-text' 'next_steps' %}
                                 <strong class="next-steps__strong">Wonderful! Is it in PDF form?</strong>
+                                <br/>
                                 Scan and save your document in high resolution
                                 to upload on your Mind My Health dashboard.
                                 {% endscribble %}
-                            </p>
+                            </div>
                             <div class="advance-directive-block-footer">
                                 <div class="advance-directive-block-footer__info-link">
                                     Learn more in our FAQs
@@ -52,14 +53,14 @@
                             <h4 class="advance-directive-block__title">
                                 Are you just starting to plan your advance care?
                             </h4>
-                            <p class="next-steps__text">
-                                {% scribble 'next-steps-upload' 'upload' %}
+                            <div class="next-steps__text">
+                                {% scribble 'download-text' 'next_steps' %}
                                 <a class="advance-directive-block__template-link" href="{{ ad_template.url }}" target="_blank" rel="noopener noreferrer">
                                     Download our free template</a>,
                                 document your desired care, and follow the
                                 instructions on your Mind My Health Dashboard.
                                 {% endscribble %}
-                            </p>
+                            </div>
                             <div class="advance-directive-block-footer">
                                 <div class="advance-directive-block-footer__info-link">
                                     Learn more in our FAQs

--- a/myhpom/templates/myhpom/accounts/next_steps_no_ad_template.html
+++ b/myhpom/templates/myhpom/accounts/next_steps_no_ad_template.html
@@ -13,7 +13,7 @@
 
             <div class="pt-1 pb-1 modal-header modal-header--subtitle pseudo-modal__header">
                 <p class="mb-0 pseudo-modal__header-caption-text">
-                    {% scribble 'next-steps-header' 'shared' %}{% lorem 24 w %}{% endscribble %}
+                    {% scribble 'header-text-no-template' 'next_steps' %}{% lorem 24 w %}{% endscribble %}
                 </p>
             </div>
 
@@ -21,6 +21,7 @@
                 <div class="row">
                     <div class="col-12">
                         <h3>Welcome!</h3>
+                        {% scribble 'welcome-text-no-template' 'next_steps' %}
                         <p>
                             Currently, Mind My Health serves North Carolina
                             and South Carolina.
@@ -39,6 +40,7 @@
                             You may still store your documents with us
                             and retrieve them upon request.
                         </p>
+                        {% endscribble %}
                         <form method="post" action="{% url 'myhpom:next_steps' %}">
                             {% csrf_token %}
                             <div class="form-group">

--- a/myhpom/tests/test_scribbler.py
+++ b/myhpom/tests/test_scribbler.py
@@ -24,10 +24,9 @@ class ScribblerTestCase(TestCase):
             for s in [s.__dict__ for s in Scribble.objects.all()]
         ]
         migration_scribbles_data = [
-            {'slug': 'signup-tos-short', 'url': 'shared'},
-            {'slug': 'next-steps-header', 'url': 'shared'},
-            {'slug': 'next-steps-download', 'url': 'shared'},
-            {'slug': 'next-steps-upload', 'url': 'shared'},
+            {'slug': 'header-text', 'url': 'next_steps'},
+            {'slug': 'download-text', 'url': 'next_steps'},
+            {'slug': 'upload-text', 'url': 'next_steps'},
         ]
         for data in migration_scribbles_data:
             self.assertIn(data, scribbles_data)


### PR DESCRIPTION
This ended up going a little deeper than we had planned:

* Updated all the scribbles for the next_steps, for states with and without templates
* Ensured that `<p>` don't surround scribbles in these templates, with .scss adjustment to replace the use of `<p>` 
* There are new scribbles in the admin
* A new naming system for scribbles: 
   * slug = the identifier for this scribble in this context
   * url = match the url_name portion of reverse('myhpom:url_name')

While pulling content out of the templates to put into the data migration, I was very tempted to take the time to create a general migration utility that would (1) parse all the templates to find scribbles, (2) delete any existing scribbles that are not found in the templates, and (3) pre-load all new scribbles into the database. It would make sense for such a utility to exist, and probably to be added to django-scribbler. It didn't make sense to spend more billable time on it without further discussion. However, it might save us time and pain down the road to do such a thing.