### PR TITLE
Mh 195  homepage faq links

### DIFF
--- a/myhpom/static/myhpom/page/_home.scss
+++ b/myhpom/static/myhpom/page/_home.scss
@@ -180,6 +180,14 @@ $banner-proportion: 60%;
     border: 2px solid $brand-blue;
 }
 
+.question:hover .question__inner-text,
+.question__inner-text:hover {
+    text-decoration: none;
+    border-bottom-width: 2px;
+    border-bottom-style: solid;
+    border-bottom-color: inherit;
+}
+
 .questions-section__link {
     color: $white!important;
 }

--- a/myhpom/static/myhpom/page/_home.scss
+++ b/myhpom/static/myhpom/page/_home.scss
@@ -180,6 +180,10 @@ $banner-proportion: 60%;
     border: 2px solid $brand-blue;
 }
 
+.questions-section__link {
+    color: $white!important;
+}
+
 /*
     "Supported by"
 */

--- a/myhpom/templates/myhpom/faq.html
+++ b/myhpom/templates/myhpom/faq.html
@@ -94,7 +94,7 @@
 if (window.location.hash) {
     var id = window.location.hash.replace(/^#/,'');
     document.getElementById(id).scrollIntoView();
-};
+}
 
 jQuery(function ($) {
     // Style the headings if the user has selected that element

--- a/myhpom/templates/myhpom/faq.html
+++ b/myhpom/templates/myhpom/faq.html
@@ -91,12 +91,12 @@
 
 {% block extra-js %}
 <script>
-if (window.location.hash) {
-    var id = window.location.hash.replace(/^#/,'');
-    document.getElementById(id).scrollIntoView();
-}
-
 jQuery(function ($) {
+    if (window.location.hash) {
+        var id = window.location.hash.replace(/^#/,'');
+        document.getElementById(id).scrollIntoView();
+    }
+    
     // Style the headings if the user has selected that element
     $('.faq-heading__section').map(function() {
         var url = $(this).prop('href');

--- a/myhpom/templates/myhpom/faq.html
+++ b/myhpom/templates/myhpom/faq.html
@@ -17,12 +17,12 @@
 <div class="col">
     <div class="row faq-heading">
         {% for section in faqs %}
-        <div class="col-md 
+        <div class="col-md
             {% if forloop.first %}faq-heading__section-wrapper--first
             {% elif forloop.last %}faq-heading__section-wrapper--last
             {% else %}faq-heading__section-wrapper{% endif %}"
         >
-            <a class="faq-heading__section 
+            <a class="faq-heading__section
                {% if forloop.first %}faq-heading__section--first
                {% elif forloop.last %}faq-heading__section--last{% endif %}"
                 href="#{{ section.name }}"
@@ -50,7 +50,7 @@
                 {% endif %}
             </div>
             {% for entry in section.entries %}
-            <div class="faq-entry">
+            <div class="faq-entry" id="{{ entry.name }}">
                 <div class="row faq-entry__header">
                     <div class="col">
                         <div class="d-flex">
@@ -91,6 +91,11 @@
 
 {% block extra-js %}
 <script>
+if (window.location.hash) {
+    var id = window.location.hash.replace(/^#/,'');
+    document.getElementById(id).scrollIntoView();
+};
+
 jQuery(function ($) {
     // Style the headings if the user has selected that element
     $('.faq-heading__section').map(function() {

--- a/myhpom/templates/myhpom/home.html
+++ b/myhpom/templates/myhpom/home.html
@@ -87,17 +87,17 @@
         <ul class="row">
             <li class="col-sm-4 questions-section__item">
                 <div class="question">
-                    What is an Advance Directive?
+                    <a class="questions-section__link" href="{% url 'myhpom:faq' %}#what_is_an_advance_directive">What is an Advance Directive?</a>
                 </div>
             </li>
             <li class="col-sm-4 questions-section__item">
                 <div class="question">
-                    Why do I need an Advance Directive?
+                    <a class="questions-section__link" href="{% url 'myhpom:faq' %}#why_do_i_need_an_advance_directive_or_other_advance_care_plan">Why do I need an Advance Directive?</a>
                 </div>
             </li>
             <li class="col-sm-4 questions-section__item">
                 <div class="question">
-                    Who benefits from my planning?
+                    <a class="questions-section__link" href="{% url 'myhpom:faq' %}">Who benefits from my planning?</a>
                 </div>
             </li>
         </ul>

--- a/myhpom/templates/myhpom/home.html
+++ b/myhpom/templates/myhpom/home.html
@@ -97,7 +97,7 @@
             </li>
             <li class="col-sm-4 questions-section__item">
                 <div class="question">
-                    <a class="questions-section__link" href="{% url 'myhpom:faq' %}">Who benefits from my planning?</a>
+                    <a class="questions-section__link" href="{% url 'myhpom:faq' %}#why_should_i_put_my_advance_directive_online">Who benefits from my planning?</a>
                 </div>
             </li>
         </ul>

--- a/myhpom/templates/myhpom/home.html
+++ b/myhpom/templates/myhpom/home.html
@@ -86,19 +86,25 @@
     <div class="container">
         <ul class="row">
             <li class="col-sm-4 questions-section__item">
-                <div class="question">
-                    <a class="questions-section__link" href="{% url 'myhpom:faq' %}#what_is_an_advance_directive">What is an Advance Directive?</a>
-                </div>
+                <a class="questions-section__link" href="{% url 'myhpom:faq' %}#what_is_an_advance_directive">
+                    <div class="question">
+                        <span class="question__inner-text">What is an Advance Directive?</span>
+                    </div>
+                </a>
             </li>
             <li class="col-sm-4 questions-section__item">
-                <div class="question">
-                    <a class="questions-section__link" href="{% url 'myhpom:faq' %}#why_do_i_need_an_advance_directive_or_other_advance_care_plan">Why do I need an Advance Directive?</a>
-                </div>
+                <a class="questions-section__link" href="{% url 'myhpom:faq' %}#why_do_i_need_an_advance_directive_or_other_advance_care_plan">
+                    <div class="question">
+                        <span class="question__inner-text">Why do I need an Advance Directive?</span>
+                    </div>
+                </a>
             </li>
             <li class="col-sm-4 questions-section__item">
-                <div class="question">
-                    <a class="questions-section__link" href="{% url 'myhpom:faq' %}#why_should_i_put_my_advance_directive_online">Who benefits from my planning?</a>
-                </div>
+                <a class="questions-section__link" href="{% url 'myhpom:faq' %}#why_should_i_put_my_advance_directive_online">
+                    <div class="question">
+                        <span class="question__inner-text">Who benefits from my planning?</span>
+                    </div>
+                </a>
             </li>
         </ul>
     </div>

--- a/myhpom/templates/myhpom/includes/header.html
+++ b/myhpom/templates/myhpom/includes/header.html
@@ -2,7 +2,7 @@
 
 <header class="shadow-sm myhpom-header {% if home %} myhpom-header--main{% endif %}">
     <nav class="navbar navbar-dark navbar-expand-lg container myhpom-header__navbar{% if home %} myhpom-header__navbar--main{% endif %}">
-        <a class="navbar-brand mb-0 mr-4 h1 img-link myhpom-header__navbar-brand{% if home %} myhpom-header__navbar-brand--home{% endif %}" href="">
+        <a class="navbar-brand mb-0 mr-4 h1 img-link myhpom-header__navbar-brand{% if home %} myhpom-header__navbar-brand--home{% endif %}" href="{% url 'myhpom:home' %}">
             <img class="myhpom-header__logo{% if home %} myhpom-header__logo--home{% endif %}" src="{% static 'myhpom/img/logo/mmh-logo-hor-color-rev@3x.png' %}" alt="Mind My Health">
             {% if home %}
                 <span class="myhpom-header__home-logo-caption">


### PR DESCRIPTION
Now the FAQ entries on the homepage link to the FAQ entry in question. As a bonus, the FAQ now has an id on each FAQ entry, and if there's a hash in the URL, the FAQ scrolls that question into view as well as opening it up.

On the homepage, I didn't see a way to make the ? above the question clickable. It's currently created with a ::before pseudo-class, so it doesn't actually exist in the DOM. Can we live with just the question itself clickable?