### PR TITLE
[MH-203] misc. faq fixes

### DIFF
--- a/myhpom/static/myhpom/page/_faq.scss
+++ b/myhpom/static/myhpom/page/_faq.scss
@@ -105,6 +105,7 @@
   color: $brand-orange;
   font-size: 1.2rem;
   font-weight: normal;
+  white-space: normal;
 }
 
 .faq-entry__header__collapser {

--- a/myhpom/templates/myhpom/faq.html
+++ b/myhpom/templates/myhpom/faq.html
@@ -63,6 +63,8 @@
                             <div class="flex-fill faq-entry__header__collapser"
                                 data-toggle="collapse"
                                 data-target="#{{ section.name }}_{{ forloop.counter }}"
+                                role="button"
+                                tabindex="0"
                             ></div>
                         </div>
                     </div>
@@ -99,7 +101,7 @@ jQuery(function ($) {
         var id = window.location.hash.replace(/^#/,'');
         document.getElementById(id).scrollIntoView();
     }
-    
+
     // Style the headings if the user has selected that element
     $('.faq-heading__section').map(function() {
         var url = $(this).prop('href');
@@ -114,12 +116,6 @@ jQuery(function ($) {
         if (name === window.location.hash) {
             $(this).collapse('show');
         }
-    });
-
-    // Change the anchor tag to reflect the current element
-    var $faqEntryHeaders = $('#faq_accordion');
-    $($faqEntryHeaders).on('shown.bs.collapse', function (e) {
-        window.location.hash = $(e.target).data('name');
     });
 });
 </script>


### PR DESCRIPTION
Assorted fixes:

- Adding `white-space: normal` fixes the fact that the headings were not wrapping on iPhones.
- Cutting that JS snippet saves us from the weird jumping scroll behavior that comes with modifying the window's hash value.
- Adding `role="button" tabindex="0"` fixes the bug actually called out in this ticket: it makes it so that the bare `div` behaves like a button for Safari's purposes. (Note: we should make it a practice to always do this when we have a button-like `div` … and there are probably many other cases that I've forgotten about!)