### PR TITLE
[MH-210] Dropping special `body` styles to fix Scribbler

### DIFF
--- a/myhpom/templates/myhpom/base.html
+++ b/myhpom/templates/myhpom/base.html
@@ -31,18 +31,20 @@
         <title>{% block title %}My Health Peace Of Mind{% endblock title %}</title>
         {% block extra-head %}{% endblock %}
     </head>
-    <body class="myhpom-page--flush-footer">
-        {% block header %}
-        {% include 'myhpom/includes/header.html' %}
-        {% endblock header %}
+    <body>
+        <div class="myhpom-page--flush-footer">
+            {% block header %}
+            {% include 'myhpom/includes/header.html' %}
+            {% endblock header %}
 
-        <main class="main myhpom-page__main--flush-footer{% block main_class %}{% endblock main_class %}">
-            <div class="{% block main_container_class %}container myhpom-page__container{% endblock main_container_class %}">
-                {% block main_content %}{% endblock main_content %}
-            </div>
-        </main>
+            <main class="main myhpom-page__main--flush-footer{% block main_class %}{% endblock main_class %}">
+                <div class="{% block main_container_class %}container myhpom-page__container{% endblock main_container_class %}">
+                    {% block main_content %}{% endblock main_content %}
+                </div>
+            </main>
 
-        {% include 'myhpom/includes/footer.html' %}
+            {% include 'myhpom/includes/footer.html' %}
+        </div>
 
         {% block extra-js %}
         {% endblock extra-js %}


### PR DESCRIPTION
Since Scribbler puts its elements directly underneath `body`, it's apparently problematic to have special styles on `body`—in our case the use of flexbox to ensure that `main` always pushes `footer` to the bottom of the screen when the size of the contents of `main` isn't great enough to do that anyway.

This addresses the issue by moving all site contents into a container `div` underneath `body` and relocating the special `body` styles to that container.