### PR TITLE
Mh 209  corrupt pdfs

### DIFF
--- a/myhpom/forms/upload_requirements.py
+++ b/myhpom/forms/upload_requirements.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
 from myhpom.models import AdvanceDirective
 
 import os
@@ -11,24 +12,24 @@ class UploadRequirementsForm(forms.ModelForm):
 
     class Meta:
         model = AdvanceDirective
-        fields = ['valid_date', 'document', 'original_filename']
+        fields = ['valid_date', 'document', 'thumbnail', 'original_filename']
 
     def clean_document(self):
-        document = self.cleaned_data['document']
+            document = self.cleaned_data['document']
         if document is None:
             return None
 
-        errors = []
-        if not document.name.lower().endswith('.pdf'):
-            errors.append(forms.ValidationError('File can only be PDF format'))
-        if document.size > settings.MAX_AD_SIZE:
+            errors = []
+            if not document.name.lower().endswith('.pdf'):
+                errors.append(forms.ValidationError('File can only be PDF format'))
+            if document.size > settings.MAX_AD_SIZE:
             errors.append(forms.ValidationError(
                 'File must be smaller than %d megabytes' % (settings.MAX_AD_SIZE / 1024 / 1024)))
 
-        if len(errors) > 0:
-            raise forms.ValidationError(errors)
+            if len(errors) > 0:
+                raise forms.ValidationError(errors)
 
-        return document
+            return document
 
     def clean(self):
         data = self.cleaned_data
@@ -37,12 +38,18 @@ class UploadRequirementsForm(forms.ModelForm):
             name, extension = os.path.splitext(data['document'].name)
             data['document'].name = "%s-%s%s" % (name, str(uuid.uuid4())[:6], extension)
 
+            # (try to) generate a thumbnail of the document
+            try:
+                thumbnail_name = os.path.splitext(data['document'].name)[0] + '.jpg'
+                thumbnail_data = AdvanceDirective(document=data['document']).render_thumbnail_data()
+                data['thumbnail'] = SimpleUploadedFile(thumbnail_name, thumbnail_data)
+            except:
+                data['document'] = ''
+                self.add_error(
+                    'document',
+                    'The uploaded PDF file was corrupt or invalid and could not be saved.',
+                )
         return data
-
-    def save(self, commit=True):
-        saved = super(forms.ModelForm, self).save(commit=commit)
-        self.instance.save_thumbnail(save=commit)
-        return saved
 
 
 class SharingForm(forms.ModelForm):

--- a/myhpom/forms/upload_requirements.py
+++ b/myhpom/forms/upload_requirements.py
@@ -15,16 +15,16 @@ class UploadRequirementsForm(forms.ModelForm):
         fields = ['valid_date', 'document', 'thumbnail', 'original_filename']
 
     def clean_document(self):
+        if 'document' in self.cleaned_data:
             document = self.cleaned_data['document']
-        if document is None:
-            return None
 
             errors = []
             if not document.name.lower().endswith('.pdf'):
                 errors.append(forms.ValidationError('File can only be PDF format'))
             if document.size > settings.MAX_AD_SIZE:
-            errors.append(forms.ValidationError(
-                'File must be smaller than %d megabytes' % (settings.MAX_AD_SIZE / 1024 / 1024)))
+                errors.append(forms.ValidationError(
+                    'File must be smaller than %d megabytes' % (settings.MAX_AD_SIZE / 1024 / 1024))
+                )
 
             if len(errors) > 0:
                 raise forms.ValidationError(errors)

--- a/myhpom/forms/upload_requirements.py
+++ b/myhpom/forms/upload_requirements.py
@@ -39,6 +39,12 @@ class UploadRequirementsForm(forms.ModelForm):
             data['document'].name = "%s-%s%s" % (name, str(uuid.uuid4())[:6], extension)
 
             # (try to) generate a thumbnail of the document
+            # NOTE: We do this here at present because we don't want to keep the PDF 
+            # if the thumbnail can't be created (= corrupt PDF = invalid form). This 
+            # assumes that processing is done in-request. In future, we will want to 
+            # move the thumbnail processing into an asynchronous queue, which means
+            # that this simple validation setup will need to be refactored into
+            # storing the document followed by tracking its state through processing.
             try:
                 thumbnail_name = os.path.splitext(data['document'].name)[0] + '.jpg'
                 thumbnail_data = AdvanceDirective(document=data['document']).render_thumbnail_data()

--- a/myhpom/migrations/0019_auto_20180817_1117.py
+++ b/myhpom/migrations/0019_auto_20180817_1117.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('myhpom', '0018_scribble_data'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='advancedirective',
+            name='thumbnail',
+            field=models.FileField(help_text=b"The first-page thumbnail image of the user's Advance Directive.", null=True, upload_to=b'myhpom/advance_directives', blank=True),
+        ),
+    ]

--- a/myhpom/models/document.py
+++ b/myhpom/models/document.py
@@ -37,20 +37,20 @@ class AdvanceDirective(models.Model):
     def filename(self):
         return self.original_filename or os.path.basename(self.document.name)
 
-    def save_thumbnail(self, save=True, res=PDF_RESOLUTION, **gsargs):
+    def render_thumbnail_data(self, res=PDF_RESOLUTION, **gsargs):
+        """return the thumbnail binary file data for the given AdvanceDirective instance"""
         mogrify = {'resize': "%dx>" % THUMBNAIL_WIDTH}
-        self.render_images(
-            save=save, save_thumbnail=True, allpages=False, res=res, mogrify=mogrify, **gsargs
+        filenames = self.render_images(
+            allpages=False, res=res, mogrify=mogrify, **gsargs
         )
+        if len(filenames) > 0:
+            with open(filenames[0], 'rb') as f:
+                return f.read()
 
-    def render_images(
-        self, save=True, save_thumbnail=True, allpages=True, res=PDF_RESOLUTION, **gsargs
-    ):
+    def render_images(self, allpages=True, res=PDF_RESOLUTION, **gsargs):
         """create one or more images of pages of the current document. 
         Requires that the AD has a document in storage
         Returns a list of (temporary) filenames (deleted after the AD object goes out of scope).
-        * save=True: if true, saves (persists) the underlying model
-        * save_thumbnail=True: if true, saves the first image as the AD.thumbnail
         * allpages=False: if true, creates all pages. if False, creates only the first page.
             (if all you want is a thumbnail, creating only the first page is MUCH faster)
         * res=150: the resolution of the output images based on the pdf page size
@@ -61,23 +61,14 @@ class AdvanceDirective(models.Model):
             * quality=90: the jpeg quality: 100 = highest.
             * mogrify=None: if given, these are post-processing arguments to mogrify (ImageMagick)
         """
-        gs = GS()  # ghostscript interpreter
         # first write the document to a temporary file in the filesystem
+        # then use ghostscript (gs) to render it
+        gs = GS()
         tempdir = tempfile.mkdtemp()
         pdf_filename = os.path.join(tempdir, self.filename)
-        with self.document.storage.open(self.document.name, 'rb') as f:
-            fd = f.read()
         with open(pdf_filename, 'wb') as f:
-            f.write(fd)
-        # then use ghostscript to render it
+            f.write(self.document.file.read())
         image_filenames = gs.render(pdf_filename, res=res, allpages=allpages, **gsargs)
-        # and save a thumbnail
-        if save_thumbnail is True and len(image_filenames or []) > 0:
-            thumbnail_filename = image_filenames[0]
-            fd = open(thumbnail_filename, 'rb').read()
-            # the save name of the thumbnail is the document name + ext
-            name = self.document.name + os.path.splitext(thumbnail_filename)[-1]
-            self.thumbnail.save(name, ContentFile(fd), save=save)
         return image_filenames
 
 

--- a/myhpom/models/document.py
+++ b/myhpom/models/document.py
@@ -28,6 +28,7 @@ class AdvanceDirective(models.Model):
     )
     thumbnail = models.FileField(
         null=True,
+        blank=True,
         upload_to='myhpom/advance_directives',
         help_text='The first-page thumbnail image of the user\'s Advance Directive.',
     )

--- a/myhpom/tests/test_advance_directive_model.py
+++ b/myhpom/tests/test_advance_directive_model.py
@@ -10,8 +10,8 @@ from myhpom.tests.factories import UserFactory
 
 PDF_FILENAME = os.path.join(os.path.dirname(__file__), 'fixtures', 'afile.pdf')
 
-class RemoveDocumentsOnDeleteTest(TestCase):
 
+class RemoveDocumentsOnDeleteTest(TestCase):
     def test_a_file(self):
         # When an AD is deleted its corresponding file and thumbnail should be deleted from
         # the system. (this test requires an actual PDF)
@@ -20,8 +20,11 @@ class RemoveDocumentsOnDeleteTest(TestCase):
             document = SimpleUploadedFile(os.path.basename(PDF_FILENAME), f.read())
         directive = AdvanceDirective(
             user=user, share_with_ehs=False, document=document, valid_date=now())
+        directive.thumbnail = SimpleUploadedFile(
+            os.path.splitext(os.path.basename(PDF_FILENAME))[0] + '.jpg',
+            directive.render_thumbnail_data(),
+        )
         directive.save()
-        directive.save_thumbnail()
         self.assertTrue(directive.document.storage.exists(directive.document.name))
         self.assertTrue(directive.thumbnail.storage.exists(directive.thumbnail.name))
 

--- a/myhpom/tests/test_upload_requirements_form.py
+++ b/myhpom/tests/test_upload_requirements_form.py
@@ -10,6 +10,7 @@ from myhpom.tests.factories import UserFactory
 
 PDF_FILENAME = os.path.join(os.path.dirname(__file__), 'fixtures', 'afile.pdf')
 
+
 class UploadRequirementsFormTestCase(TestCase):
     """
     * not valid:
@@ -25,27 +26,41 @@ class UploadRequirementsFormTestCase(TestCase):
         user = UserFactory()
         self.directive = AdvanceDirective(user=user, share_with_ehs=False)
         with open(PDF_FILENAME, 'rb') as f:
-            self.valid_file = SimpleUploadedFile(os.path.basename(PDF_FILENAME), f.read())
+            self.pdf_data = f.read()
 
-    @override_settings(MAX_AD_SIZE=10)
-    def test_not_valid(self):
-        invalid_data = [
+    def test_not_valid_dates(self):
+        invalid_dates = [
             {},
             {'valid_date': ''},
             {'valid_date': 'not-a-date'},
             {'valid_date': (date.today() + timedelta(1)).strftime("%Y-%m-%d")},  # tomorrow!
         ]
-        for data in invalid_data:
-            form = UploadRequirementsForm(data, files={'document': self.valid_file})
+        for data in invalid_dates:
+            document = SimpleUploadedFile(os.path.basename(PDF_FILENAME), self.pdf_data)
+            form = UploadRequirementsForm(data, files={'document': document})
             self.assertFalse(form.is_valid())
 
-        # If the date is valid, but the file isn't
-        valid_date = (date.today() - timedelta(1)).strftime("%Y-%m-%d")
-        toobig_valid_file = SimpleUploadedFile('toobig.pdf', 'binary_contents')
-        invalid_file = SimpleUploadedFile('afile.txt', 'binary_contents')
-        for some_file in [toobig_valid_file, invalid_file]:
-            form = UploadRequirementsForm(data={'valid_date': valid_date}, files={'document': some_file})
+    def test_not_valid_files(self):
+        valid_data = {'valid_date': date.today().strftime("%Y-%m-%d")}
+        invalid_files_list = [
+            {'document': SimpleUploadedFile("afile.txt", "not-binary-pdf-data")},
+            {'document': SimpleUploadedFile("afile.pdf", "also-not-binary-pdf-data")},
+        ]
+        for invalid_files in invalid_files_list:
+            form = UploadRequirementsForm(data=valid_data, files=invalid_files)
             self.assertFalse(form.is_valid())
+
+
+    @override_settings(MAX_AD_SIZE=10)
+    def test_document_too_big(self):
+        # we can test the MAX_AD_SIZE setting by overriding it with a very small value
+        # everything else is valid
+        valid_date = (date.today() - timedelta(1)).strftime("%Y-%m-%d")
+        toobig_valid_file = SimpleUploadedFile('toobig.pdf', self.pdf_data)
+        form = UploadRequirementsForm(
+            data={'valid_date': valid_date}, files={'document': toobig_valid_file}
+        )
+        self.assertFalse(form.is_valid())
 
     def test_valid(self):
         valid_data = [
@@ -53,14 +68,21 @@ class UploadRequirementsFormTestCase(TestCase):
             {'valid_date': (date.today() - timedelta(1)).strftime("%Y-%m-%d")},  # yesterday!
         ]
         for data in valid_data:
-            form = UploadRequirementsForm(data, instance=self.directive, files={'document': self.valid_file})
+            document = SimpleUploadedFile(os.path.basename(PDF_FILENAME), self.pdf_data)
+            form = UploadRequirementsForm(
+                data, instance=self.directive, files={'document': document}
+            )
             self.assertTrue(form.is_valid(), msg=data)
             form.save()
 
     def test_clean(self):
         # When a file is cleaned and saved, the filename is modified to prevent
         # clashing and guessing from would-be attackers.
-        form = UploadRequirementsForm({'valid_date': date.today().strftime("%Y-%m-%d")}, instance=self.directive, files={'document': self.valid_file})
+        form = UploadRequirementsForm(
+            {'valid_date': date.today().strftime("%Y-%m-%d")},
+            instance=self.directive,
+            files={'document': SimpleUploadedFile(os.path.basename(PDF_FILENAME), self.pdf_data)},
+        )
         self.assertTrue(form.is_valid())
         form.save()
         self.assertNotEqual('afile.pdf', basename(self.directive.document.name))

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ django-scribbler==0.9.0
 factory-boy==2.8.1
 libsass==0.14.5
 python-dotenv==0.8.2
-bgs==0.4.0
+bgs==0.6.1
 pyyaml==3.13


### PR DESCRIPTION
Unfortunately this PR will require another `./hsctl rebuild` to ensure that the requirements are properly updated.

There are quite a few low-level changes here, but the bottom line is that corrupt PDFs now provide a validation error and are not saved, but an error message is returned and displayed in the upload form. In order to accomplish this,

* creating the thumbnail is moved out of UploadRequirementsForm.save() and into form.clean(), so that the failure to create a thumbnail results in a validation error and the redisplay of the form with an error message.
* in the AdvanceDirective model, the save_thumbnail() is replaced by a render_thumbnail_data() method, which only returns the binary file data without modifying the instance. This also makes the render_images() method functional rather than mutating. (I would have converted these into classmethods, but they rely on an instance, so we might as well make them immutable instance methods.)
* A tiny migration is added to make AdvanceDirective.thumbnail(blank=True).
* A number of cleanups were done to tests in order to have them pass under the new AD regime.