### PR TITLE
Mh 201  straggling lorem

### DIFF
--- a/myhpom/templates/myhpom/home.html
+++ b/myhpom/templates/myhpom/home.html
@@ -128,7 +128,7 @@
             <div class="col-12">
                 <div class="how-it-works-section__title">How it works.</div>
                 <p class="ml-auto mr-auto how-it-works-section__subtitle">
-                    {% lorem 24 w %}
+                    Your simple step-by-step guide to empowering your advance care planning with Mind My Health.
                 </p>
             </div>
         </div>

--- a/myhpom/templates/myhpom/home.html
+++ b/myhpom/templates/myhpom/home.html
@@ -127,7 +127,7 @@
         <div class="row">
             <div class="col-12">
                 <div class="how-it-works-section__title">How it works.</div>
-                <p class="ml-auto mr-auto how-it-works-section__subtitle">
+                <p class="mx-auto how-it-works-section__subtitle">
                     Your simple step-by-step guide to empowering your advance care planning with Mind My Health.
                 </p>
             </div>

--- a/myhpom/templates/myhpom/home.html
+++ b/myhpom/templates/myhpom/home.html
@@ -1,6 +1,5 @@
 {% extends "myhpom/base.html" %}
 {% load staticfiles %}
-{% load scribbler_tags %}
 
 {% block header %}
 {% include 'myhpom/includes/header.html' with home=1 %}
@@ -15,7 +14,7 @@
             Own your care. Plan in advance.
         </div>
         <div class="hero-section__subtitle">
-            {% lorem 12 w %}
+            Your online tool to keep your advance care plan in check.
         </div>
         <div class="mt-2 hero-section__start-now">
             <a class="btn btn-secondary hero-section__start-now-button" href="{% url 'myhpom:signup' %}">Start Now</a>
@@ -128,9 +127,9 @@
         <div class="row">
             <div class="col-12">
                 <div class="how-it-works-section__title">How it works.</div>
-                {% scribble 'homepage' 'how-it-works' %}
-                <p class="ml-auto mr-auto how-it-works-section__subtitle">{% lorem 24 w %}</p>
-                {% endscribble %}
+                <p class="ml-auto mr-auto how-it-works-section__subtitle">
+                    {% lorem 24 w %}
+                </p>
             </div>
         </div>
         <ul class="row">


### PR DESCRIPTION
Just a couple of lorem blocks on the homepage replaced with real content. Here are the comps and a Slack note for comparison. 

<img width="616" alt="screenshot 2018-08-20 10 29 35" src="https://user-images.githubusercontent.com/40370408/44350047-102efd80-a464-11e8-9d29-40b4433aa23e.png">
<img width="407" alt="screenshot 2018-08-20 10 29 58" src="https://user-images.githubusercontent.com/40370408/44350048-102efd80-a464-11e8-89c7-15417d80bfcd.png">

> Gannon Hubbard [10:10 AM]
> FYI on MH-201, there is still a line of lorem below the How It Works header on the desktop home page comp. shane says that the line appears on the mobile comp, and reads:
> > Your simple step-by-step guide to empowering your advance care planning with Mind My Health.