### PR TITLE
[MH-221] Updates deploy notes with info about sites config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ following steps have been used to set up docker (for hsctl) and java (for
 jenkins) and add the deploy user to docker group. See the [deployment
 docs](deploy/README.md) for more information.
 
+To deploy this application, login to the [Jenkins
+server](https://ci.mindmyhealth.org) and start the 'Deploy MMH' job.
+
+Note that this project uses the [Django Sites
+plugin](https://docs.djangoproject.com/en/2.1/ref/contrib/sites/): when creating
+a new environment, or restoring databases from production to staging be sure to
+login to the admin interface and change the site domain to the correct value for
+that environment.
+
 Code Style Notes
 ================
 


### PR DESCRIPTION
It turns out that the template is provided a domain value that, short of writing our own replacement for `PasswordResetForm`, can only be usefully changed if we are using the django sites plugin. Since we are, I opted to update the value of the domain on staging and make a note of its use under the deployment section of our README.

Ultimately I'd love to see this kind of thing end up in a 'backup/restore' type document - which we don't yet have for this project :/