### PR TITLE
[MH-239] Don't show form if reset link is invalid.

### DIFF
--- a/myhpom/templates/registration/password_reset_confirm.html
+++ b/myhpom/templates/registration/password_reset_confirm.html
@@ -5,18 +5,6 @@
 {% block title %}Change password{% endblock %}
 
 {% block main_content %}
-  {% if validlink %}
-    <form method="post">
-      {% csrf_token %}
-      {{ form.as_p }}
-      <button type="submit">Change password</button>
-    </form>
-  {% else %}
-    <p>
-      The password reset link was invalid, possibly because it has already been used.
-      Please request a new password reset.
-    </p>
-  {% endif %}
 <div
     class="modal show pseudo-modal"
     data-close-href="{% url 'myhpom:home' %}"
@@ -42,6 +30,7 @@
             <div class="modal-body pseudo-modal__body">
                 <div class="row">
                 <div class="col-md-7 mx-auto">
+                    {% if validlink %}
                     <form method="post">
                         {% csrf_token %}
 
@@ -89,6 +78,12 @@
                             </div>
                         </div>
                     </form>
+                    {% else %}
+                    <p>
+                        The password reset link was invalid, possibly because it has already been used.
+                        Please request a new password reset.
+                    </p>
+                    {% endif %}
                 </div>
                 </div>
             </div>


### PR DESCRIPTION
The original default template was also left up at the top...refactored
it out.