### PR TITLE
[MH-230] Fixes failed dropdb on test.

### DIFF
--- a/hsctl
+++ b/hsctl
@@ -247,18 +247,22 @@ loaddb_hs() {
     # Ensure all prior connections to the database are removed prior to dropping the database
     docker exec -u postgres -ti postgis psql -c "REVOKE CONNECT ON DATABASE postgres FROM public;"
     docker exec -u postgres -ti postgis psql -c "SELECT pid, pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid();"
+    # Make sure no services are connected to the database so that the database
+    # can be dropped:
+    docker-compose stop hydroshare
     echo "  - docker exec -u hydro-service hydroshare dropdb -U postgres -h postgis postgres"
-    docker exec -u hydro-service hydroshare dropdb -U postgres -h postgis postgres
+    docker run -u hydro-service hydroshare dropdb -U postgres -h postgis postgres
     echo "  - docker exec -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION postgis;'"
-    docker exec -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION postgis;'
+    docker run -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION postgis;'
     echo "  - docker exec -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION hstore;'"
-    docker exec -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION hstore;'
+    docker run -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION hstore;'
     echo "  - docker exec -u hydro-service hydroshare createdb -U postgres -h postgis postgres --encoding UNICODE --template=template1"
-    docker exec -u hydro-service hydroshare createdb -U postgres -h postgis postgres --encoding UNICODE --template=template1
+    docker run -u hydro-service hydroshare createdb -U postgres -h postgis postgres --encoding UNICODE --template=template1
     echo "  - docker exec -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -w -c 'SET client_min_messages TO WARNING;'"
-    docker exec -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -w -c 'SET client_min_messages TO WARNING;'
+    docker run -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -w -c 'SET client_min_messages TO WARNING;'
     echo "  - docker exec -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -q -f ${HS_DATABASE}"
-    docker exec -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -q -f ${HS_DATABASE}
+    docker run -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -q -f ${HS_DATABASE}
+    docker-compose up -d
 }
 
 migrate_hs() {

--- a/hsctl
+++ b/hsctl
@@ -250,18 +250,18 @@ loaddb_hs() {
     # Make sure no services are connected to the database so that the database
     # can be dropped:
     docker-compose stop hydroshare
-    echo "  - docker exec -u hydro-service hydroshare dropdb -U postgres -h postgis postgres"
-    docker run -u hydro-service hydroshare dropdb -U postgres -h postgis postgres
-    echo "  - docker exec -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION postgis;'"
-    docker run -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION postgis;'
-    echo "  - docker exec -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION hstore;'"
-    docker run -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION hstore;'
-    echo "  - docker exec -u hydro-service hydroshare createdb -U postgres -h postgis postgres --encoding UNICODE --template=template1"
-    docker run -u hydro-service hydroshare createdb -U postgres -h postgis postgres --encoding UNICODE --template=template1
-    echo "  - docker exec -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -w -c 'SET client_min_messages TO WARNING;'"
-    docker run -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -w -c 'SET client_min_messages TO WARNING;'
-    echo "  - docker exec -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -q -f ${HS_DATABASE}"
-    docker run -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -q -f ${HS_DATABASE}
+    echo "  - docker run --rm -u hydro-service hydroshare dropdb -U postgres -h postgis postgres"
+    docker-compose run --rm -u hydro-service hydroshare dropdb -U postgres -h postgis postgres
+    echo "  - docker-compose run --rm -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION postgis;'"
+    docker-compose run --rm -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION postgis;'
+    echo "  - docker-compose run --rm -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION hstore;'"
+    docker-compose run --rm -u hydro-service hydroshare psql -U postgres -h postgis -d template1 -w -c 'CREATE EXTENSION hstore;'
+    echo "  - docker-compose run --rm -u hydro-service hydroshare createdb -U postgres -h postgis postgres --encoding UNICODE --template=template1"
+    docker-compose run --rm -u hydro-service hydroshare createdb -U postgres -h postgis postgres --encoding UNICODE --template=template1
+    echo "  - docker-compose run --rm -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -w -c 'SET client_min_messages TO WARNING;'"
+    docker-compose run --rm -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -w -c 'SET client_min_messages TO WARNING;'
+    echo "  - docker-compose run --rm -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -q -f ${HS_DATABASE}"
+    docker-compose run --rm -u hydro-service hydroshare psql -U postgres -h postgis -d postgres -q -f ${HS_DATABASE}
     docker-compose up -d
 }
 


### PR DESCRIPTION
Chris noticed that the `hsctl rebuild --db` was not rebuilding the database cleanly. He saw:

```
 - docker exec -u hydro-service hydroshare dropdb -U postgres -h postgis postgres
dropdb: database removal failed: ERROR:  database "postgres" is being accessed by other users
DETAIL:  There is 1 other session using the database.
```

and

```
psql:pg.myhpomdevelopment.sql:25805: ERROR:  multiple primary keys for table "django_migrations" are not allowed
```

The issue was that the hydroshare docker container was 'online' and connected to the database.