### PR TITLE
[MH-247] IE 11 modal regressions

### DIFF
--- a/myhpom/templates/myhpom/accounts/next_steps_no_ad_template.html
+++ b/myhpom/templates/myhpom/accounts/next_steps_no_ad_template.html
@@ -21,9 +21,11 @@
             </div>
 
             <div class="pt-1 pb-1 modal-header modal-header--subtitle pseudo-modal__header">
-                <p class="mb-0 pseudo-modal__header-caption-text">
-                    {% scribble 'header-text-no-template' 'next_steps' %}{% lorem 24 w %}{% endscribble %}
-                </p>
+                {% scribble 'header-text-no-template' 'next_steps' %}
+                    <p class="mb-0 pseudo-modal__header-caption-text">
+                        {% lorem 24 w %}
+                    </p>
+                {% endscribble %}
             </div>
 
             <div class="modal-body pseudo-modal__body">

--- a/myhpom/templates/registration/login.html
+++ b/myhpom/templates/registration/login.html
@@ -12,9 +12,11 @@
     <div class="modal-dialog pseudo-modal__dialog" role="document">
         <div class="modal-content pseudo-modal__content">
             <div class="pseudo-modal__pre-header">
-                <img class="ml-auto pseudo-modal__logo" src="{% static 'myhpom/img/logo/mmh-logo-hor-beta-color-rev@3x.png' %}" alt="">
+                <div class="pseudo-modal__logo-container">
+                    <img class="pseudo-modal__logo" src="{% static 'myhpom/img/logo/mmh-logo-hor-beta-color-rev@3x.png' %}" alt="">
+                </div>
                 <div
-                    class="ml-auto oi oi-x pseudo-modal__close-button"
+                    class="oi oi-x pseudo-modal__close-button"
                     role="button"
                     tabindex="0"
                     data-close-href="{% url 'myhpom:home' %}"

--- a/myhpom/templates/registration/password_reset_complete.html
+++ b/myhpom/templates/registration/password_reset_complete.html
@@ -12,9 +12,11 @@
     <div class="modal-dialog pseudo-modal__dialog" role="document">
         <div class="modal-content pseudo-modal__content">
             <div class="pseudo-modal__pre-header">
-                <img class="ml-auto pseudo-modal__logo" src="{% static 'myhpom/img/logo/mmh-logo-hor-beta-color-rev@3x.png' %}" alt="">
+                <div class="pseudo-modal__logo-container">
+                    <img class="pseudo-modal__logo" src="{% static 'myhpom/img/logo/mmh-logo-hor-beta-color-rev@3x.png' %}" alt="">
+                </div>
                 <div
-                    class="ml-auto oi oi-x pseudo-modal__close-button"
+                    class="oi oi-x pseudo-modal__close-button"
                     role="button"
                     tabindex="0"
                     data-close-href="{% url 'myhpom:home' %}"

--- a/myhpom/templates/registration/password_reset_confirm.html
+++ b/myhpom/templates/registration/password_reset_confirm.html
@@ -12,9 +12,11 @@
     <div class="modal-dialog pseudo-modal__dialog" role="document">
         <div class="modal-content pseudo-modal__content">
             <div class="pseudo-modal__pre-header">
-                <img class="ml-auto pseudo-modal__logo" src="{% static 'myhpom/img/logo/mmh-logo-hor-beta-color-rev@3x.png' %}" alt="">
+                <div class="pseudo-modal__logo-container">
+                    <img class="pseudo-modal__logo" src="{% static 'myhpom/img/logo/mmh-logo-hor-beta-color-rev@3x.png' %}" alt="">
+                </div>
                 <div
-                    class="ml-auto oi oi-x pseudo-modal__close-button"
+                    class="oi oi-x pseudo-modal__close-button"
                     role="button"
                     tabindex="0"
                     data-close-href="{% url 'myhpom:home' %}"

--- a/myhpom/templates/registration/password_reset_done.html
+++ b/myhpom/templates/registration/password_reset_done.html
@@ -12,9 +12,11 @@
     <div class="modal-dialog pseudo-modal__dialog" role="document">
         <div class="modal-content pseudo-modal__content">
             <div class="pseudo-modal__pre-header">
-                <img class="ml-auto pseudo-modal__logo" src="{% static 'myhpom/img/logo/mmh-logo-hor-beta-color-rev@3x.png' %}" alt="">
+                <div class="pseudo-modal__logo-container">
+                    <img class="pseudo-modal__logo" src="{% static 'myhpom/img/logo/mmh-logo-hor-beta-color-rev@3x.png' %}" alt="">
+                </div>
                 <div
-                    class="ml-auto oi oi-x pseudo-modal__close-button"
+                    class="oi oi-x pseudo-modal__close-button"
                     role="button"
                     tabindex="0"
                     data-close-href="{% url 'myhpom:home' %}"

--- a/myhpom/templates/registration/password_reset_form.html
+++ b/myhpom/templates/registration/password_reset_form.html
@@ -12,9 +12,11 @@
     <div class="modal-dialog pseudo-modal__dialog" role="document">
         <div class="modal-content pseudo-modal__content">
             <div class="pseudo-modal__pre-header">
-                <img class="ml-auto pseudo-modal__logo" src="{% static 'myhpom/img/logo/mmh-logo-hor-beta-color-rev@3x.png' %}" alt="">
+                <div class="pseudo-modal__logo-container">
+                    <img class="pseudo-modal__logo" src="{% static 'myhpom/img/logo/mmh-logo-hor-beta-color-rev@3x.png' %}" alt="">
+                </div>
                 <div
-                    class="ml-auto oi oi-x pseudo-modal__close-button"
+                    class="oi oi-x pseudo-modal__close-button"
                     role="button"
                     tabindex="0"
                     data-close-href="{% url 'myhpom:home' %}"


### PR DESCRIPTION
Two issues fixed here:

- The pseudo-header changes implemented in the `accounts/` templates were not spread to the `registration/` templates, with predictable bad results.
- There was a `{% scribble %}` block inside a `p`, again with the usual bad results: the repair strategy employed by IE 11 to get rid of `<p><div/></p>` nesting caused breakage in combination with the new layout rules.

In the long run, for the second issue, I think we're going to want a patch to django-scribbler that lets you specify the type of container element that `{% scribble %}` results in so that we can use a `span` as appropriate (or some such).