### PR TITLE
[mh-248] enable long emails, email-based authentication

### DIFF
--- a/hydroshare/settings.py
+++ b/hydroshare/settings.py
@@ -361,3 +361,5 @@ LOGIN_REDIRECT_URL = 'myhpom:dashboard'
 
 # Custom test runner that excludes apps we don't use
 TEST_RUNNER = 'myhpom.tests.runner.LimitedTestSuiteRunner'
+
+AUTHENTICATION_BACKENDS = ['myhpom.auth.EmailAuthBackend']

--- a/myhpom/auth.py
+++ b/myhpom/auth.py
@@ -1,10 +1,12 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 
+
 class EmailAuthBackend(ModelBackend):
     """
     Authenticate a user via email (which is unique in this system) rather than username.
     """
+
     def authenticate(self, username=None, password=None, **kwargs):
         User = get_user_model()
         try:
@@ -12,6 +14,6 @@ class EmailAuthBackend(ModelBackend):
         except User.DoesNotExist:
             return None
         else:
-            if user.check_password(password):
+            if user.check_password(password) and user.is_active:
                 return user
         return None

--- a/myhpom/auth.py
+++ b/myhpom/auth.py
@@ -1,0 +1,17 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.backends import ModelBackend
+
+class EmailAuthBackend(ModelBackend):
+    """
+    Authenticate a user via email (which is unique in this system) rather than username.
+    """
+    def authenticate(self, username=None, password=None, **kwargs):
+        User = get_user_model()
+        try:
+            user = User.objects.get(email=username)
+        except User.DoesNotExist:
+            return None
+        else:
+            if user.check_password(password):
+                return user
+        return None

--- a/myhpom/models/user.py
+++ b/myhpom/models/user.py
@@ -1,7 +1,8 @@
 from django.db import models
 from django.contrib.auth.models import User
 from myhpom import validators
-import base64, hashlib
+import base64
+import hashlib
 
 """
 * Connect a pre_save receiver/hook to the User model, and use this model in all imports
@@ -10,8 +11,9 @@ import base64, hashlib
 
 User.__unicode__ = lambda u: u.email
 
+
 def get_username(email):
-    """unique username as hash of the email. 
+    """unique username as hash of the email.
     Must be <= 30 characters long. 30, Django? Really?
     """
     h = hashlib.new('sha1')  # the longest hash algorithm that base64-encodes at <= 30 characters

--- a/myhpom/models/user.py
+++ b/myhpom/models/user.py
@@ -1,8 +1,22 @@
 from django.db import models
 from django.contrib.auth.models import User
 from myhpom import validators
+import base64, hashlib
 
-"""Connect a pre_save receiver/hook to the User model, and use this model in all imports"""
+"""
+* Connect a pre_save receiver/hook to the User model, and use this model in all imports
+* monkeypatch User.__unicode__ to return the email address
+"""
+
+User.__unicode__ = lambda u: u.email
+
+def get_username(email):
+    """unique username as hash of the email. 
+    Must be <= 30 characters long. 30, Django? Really?
+    """
+    h = hashlib.new('sha1')  # the longest hash algorithm that base64-encodes at <= 30 characters
+    h.update(email)
+    return base64.urlsafe_b64encode(h.digest())
 
 
 def user_pre_save_receiver(sender, instance, **kwargs):
@@ -11,12 +25,12 @@ def user_pre_save_receiver(sender, instance, **kwargs):
         * first_name
         * last_name
         * email
-    * Set the username to the email
+    * Set the username to (a hash of) the email
     """
     validators.name_validator(instance.first_name)
     validators.name_validator(instance.last_name)
     validators.email_validator(instance.email)
-    instance.username = instance.email
+    instance.username = get_username(instance.email)
 
 
 models.signals.pre_save.connect(user_pre_save_receiver, sender=User)

--- a/myhpom/tests/test_choose_network_view.py
+++ b/myhpom/tests/test_choose_network_view.py
@@ -21,7 +21,7 @@ class ChooseNetworkTestCase(TestCase):
         self.user = UserFactory()
         self.user.set_password('password')
         self.user.save()
-        self.client.login(username=self.user.username, password='password')
+        self.client.login(username=self.user.email, password='password')
         self.url = reverse('myhpom:choose_network')
         self.user.userdetails.state = models.State.objects.get(name="NC")
         self.user.userdetails.save()

--- a/myhpom/tests/test_context_processors.py
+++ b/myhpom/tests/test_context_processors.py
@@ -19,7 +19,7 @@ class ContactEmailProcessorTestCase(TestCase):
         user = UserFactory()
         user.set_password('password')
         user.save()
-        self.assertTrue(self.client.login(username=user.username, password='password'))
+        self.assertTrue(self.client.login(username=user.email, password='password'))
         for example_email in ('foo@example.com', 'bar@example.com', ):
             response = self.client.get(reverse('myhpom:dashboard'))
             self.assertEqual(response.context['contact_email'], settings.CONTACT_EMAIL)

--- a/myhpom/tests/test_dashboard_view.py
+++ b/myhpom/tests/test_dashboard_view.py
@@ -19,7 +19,7 @@ class DashboardTestCase(TestCase):
         user = UserFactory()
         user.set_password('password')
         user.save()
-        self.assertTrue(self.client.login(username=user.username, password='password'))
+        self.assertTrue(self.client.login(username=user.email, password='password'))
         response = self.client.get(self.url)
         self.assertEqual(200, response.status_code)
         self.assertTemplateUsed('myhpom/dashboard.html')
@@ -34,7 +34,7 @@ class DashboardTestCase(TestCase):
         user.save()
         advancedirective = AdvanceDirective(user=user, valid_date=now(), share_with_ehs=False)
         advancedirective.save()
-        self.assertTrue(self.client.login(username=user.username, password='password'))
+        self.assertTrue(self.client.login(username=user.email, password='password'))
         response = self.client.get(self.url)
         self.assertEqual(200, response.status_code)
         self.assertTemplateUsed('myhpom/dashboard.html')
@@ -49,7 +49,7 @@ class DashboardTestCase(TestCase):
         user = UserFactory()
         user.set_password('password')
         user.save()
-        self.assertTrue(self.client.login(username=user.username, password='password'))
+        self.assertTrue(self.client.login(username=user.email, password='password'))
 
         user.userdetails.is_organ_donor = False
         user.userdetails.save()

--- a/myhpom/tests/test_edit_profile_view.py
+++ b/myhpom/tests/test_edit_profile_view.py
@@ -24,7 +24,7 @@ class EditProfileViewTestCase(TestCase):
         user = UserFactory()
         user.set_password('password')
         user.save()
-        self.assertTrue(self.client.login(username=user.username, password='password'))
+        self.assertTrue(self.client.login(username=user.email, password='password'))
         response = self.client.get(self.url)
         self.assertEqual(200, response.status_code)
         self.assertTemplateUsed('myhpom/profile/edit.html')
@@ -47,7 +47,8 @@ class EditProfileViewTestCase(TestCase):
         user = UserFactory()
         user.set_password('password')
         user.save()
-        self.assertTrue(self.client.login(username=user.username, password='password'))
+        self.assertTrue(self.client.login(username=user.email, password='password'))
+
         # since we test the form elsewhere, we can minimize our valid data test
         valid_post_data = dict(
             state=user.userdetails.state.name,

--- a/myhpom/tests/test_irods_view.py
+++ b/myhpom/tests/test_irods_view.py
@@ -72,7 +72,7 @@ class IrodsDownloadTest(TestCase):
         self.assertEqual(404, response.status_code)
 
         # When the user is logged in, they can retrieve their file:
-        self.assertTrue(self.client.login(username=user.username, password='password'))
+        self.assertTrue(self.client.login(username=user.email, password='password'))
         response = self.client.get(self.url)
         self.assertEqual(''.join(response.streaming_content), 'content')
 

--- a/myhpom/tests/test_next_steps_view.py
+++ b/myhpom/tests/test_next_steps_view.py
@@ -21,7 +21,7 @@ class NextStepsTestCase(TestCase):
         self.assertEqual(302, response.status_code)
 
     def test_no_upload_links_with_invalid_state(self):
-        self.client.login(username=self.user.username, password='password')
+        self.client.login(username=self.user.email, password='password')
         response = self.client.get(self.url)
         self.assertEqual(200, response.status_code)
         self.assertTemplateUsed('myhpom/accounts/next_steps_no_ad_template.html')
@@ -31,7 +31,7 @@ class NextStepsTestCase(TestCase):
         When you're on the "state not supported" version of the form,
         you can use a POST request to set a custom provider.
         """
-        self.client.login(username=self.user.username, password='password')
+        self.client.login(username=self.user.email, password='password')
         response = self.client.get(self.url)
         self.assertEqual(200, response.status_code)
         self.assertTemplateUsed('myhpom/accounts/next_steps_no_ad_template.html')
@@ -48,7 +48,7 @@ class NextStepsTestCase(TestCase):
     def test_upload_links_with_valid_state(self):
         self.user.userdetails.state = State.objects.get(name='NC')
         self.user.userdetails.save()
-        self.client.login(username=self.user.username, password='password')
+        self.client.login(username=self.user.email, password='password')
         response = self.client.get(reverse('myhpom:next_steps'))
         self.assertEqual(200, response.status_code)
         self.assertTemplateUsed('myhpom/accounts/signup.html')

--- a/myhpom/tests/test_upload_view.py
+++ b/myhpom/tests/test_upload_view.py
@@ -16,7 +16,7 @@ class UploadMixin:
         user = UserFactory()
         user.set_password('password')
         user.save()
-        self.assertTrue(self.client.login(username=user.username, password='password'))
+        self.assertTrue(self.client.login(username=user.email, password='password'))
         return user
 
     def test_not_logged_in(self):

--- a/myhpom/tests/test_user_model.py
+++ b/myhpom/tests/test_user_model.py
@@ -17,10 +17,10 @@ class UserModelTestCase(TestCase):
         }
 
     def test_save_user_without_username(self):
-        """saving User without username results in username = email"""
+        """saving User without username results in username not null"""
         user = User(**self.user_data)
         user.save()
-        self.assertEqual(user.email, user.username)
+        self.assertIsNotNone(user.username)
 
     def test_save_invalid_user_fails(self):
         """first_name and last_name are not only required, but they have to be alphanumeric,


### PR DESCRIPTION
We have had a long-standing bug that arises from the fact that user.username was being set to user.email during User save (via pre-save receiver).  But User.username can only be 30 characters long. So, any email longer than 30 characters was causing 500 errors during signup and edit profile.

The solution is twofold: 

1. When saving the User, the username is now a hash of the email that is algorithmically limited to 28 characters (base64 encoded SHA-1 hash digest) while still giving a reasonable guarantee of uniqueness (although SHA-1 hash collisions do occur on very rare occasion — something I haven't accounted for).

2. Far larger a change, I've switched the system to email-based authentication by creating a custom EmailAuthBackend (in myhpom.auth) and assigning it in settings. This also affects multiple places in the app: Every test that uses Client.login() with username had to be switched to email. So most of the changes are of that sort.

In the end, this gets us part of the way toward our goal of creating a custom user model that uses email-based authentication. 