### PR TITLE
Mh 206  links to faq in signup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ deploy/.vault-key
 deploy/*.retry
 myhpom/static/myhpom/myhpom.css
 hydroshare/public/media
+append-hosts

--- a/myhpom/static/myhpom/data/faq.yaml
+++ b/myhpom/static/myhpom/data/faq.yaml
@@ -82,6 +82,18 @@
     name: who_can_sign_up_to_become_an_organ_donor
     answer: "Everyone! An individual of any age is able to join the organ, eye and tissue donor registry. This includes individuals who have been sick, had cancer in the past, or who have HIV or Hepatitis C."
     tooltip: "Everyone! An individual of any age is able to join the organ, eye and tissue donor registry. "
+  - question: Why does Mind My Health only directly serve North Carolina and South Carolina at this time?
+    name: why_only_north_south_carolina
+    answer: Mind My Health is a project of The Carolinas Center for Hospice and End of Life Care (TCC), a nonprofit hospice association with members in North Carolina and South Carolina. TCC developed Mind My Health in partnership with the support of a grant from The Duke Endowment to expand access in the Carolinas to creation and accessible storage of Advance Care Planning Documents.
+    tooltip: Mind My Health is a project of The Carolinas Center for Hospice and End of Life Care (TCC), a nonprofit hospice association with members in North Carolina and South Carolina.
+  - question: How do I find my healthcare network?
+    name: how_do_i_find_my_healthcare_network
+    answer: Many physicians belong to a hospital network, so start by asking your physician if they belong to a network. You can also ask them what network your nearest hospital belongs to.
+    tooltip: Many physicians belong to a hospital network, so start by asking your physician if they belong to a network. You can also ask them what network your nearest hospital belongs to.
+  - question: Why is Medicare not an option? 
+    name: why_is_medicare_not_an_option
+    answer: Medicare does not operate hospitals or doctor’s offices, so it is not a network. Check with your doctor about their health network or ask them what the network for the nearest hospital is.
+    tooltip: Medicare does not operate hospitals or doctor’s offices, so it is not a network. Check with your doctor about their health network or ask them what the network for the nearest hospital is.
 
 - name: understanding
   description: Understanding My Plan

--- a/myhpom/templates/myhpom/accounts/choose_network.html
+++ b/myhpom/templates/myhpom/accounts/choose_network.html
@@ -28,8 +28,8 @@
             <div class="pt-0 modal-body pseudo-modal__body">
                 <div class="row">
                     <div class="col-12 col--centered">
-                        <small class="mx-1 pseudo-modal__tooltip-text">How do I find my healthcare network?</small>
-                        <small class="mx-1 pseudo-modal__tooltip-text">Why is Medicare / Medicaid not an option?</small>
+                        <a class="advance-directive-block__template-link" href="{% url 'myhpom:faq' %}#how_do_i_find_my_healthcare_network" data-no-ajax="true" target="_blank" rel="noopener noreferrer"><small class="mx-1 pseudo-modal__tooltip-text">How do I find my healthcare network?</small></a>
+                        <a class="advance-directive-block__template-link" href="{% url 'myhpom:faq' %}#why_is_medicare_not_an_option" data-no-ajax="true" target="_blank" rel="noopener noreferrer"><small class="mx-1 pseudo-modal__tooltip-text">Why is Medicare / Medicaid not an option?</small></a>
                     </div>
                 </div>
 

--- a/myhpom/templates/myhpom/accounts/next_steps.html
+++ b/myhpom/templates/myhpom/accounts/next_steps.html
@@ -46,7 +46,9 @@
                             </div>
                             <div class="advance-directive-block-footer">
                                 <div class="advance-directive-block-footer__info-link">
-                                    Learn more in our FAQs
+                                    <a class="advance-directive-block__template-link" href="{% url 'myhpom:faq' %}" data-no-ajax="true" target="_blank" rel="noopener noreferrer">
+                                        Learn more in our FAQs
+                                    </a>
                                 </div>
                                 <div class="advance-directive-block-footer__caption">
                                     Link will open in new window
@@ -67,7 +69,9 @@
                             </div>
                             <div class="advance-directive-block-footer">
                                 <div class="advance-directive-block-footer__info-link">
-                                    Learn more in our FAQs
+                                    <a class="advance-directive-block__template-link" href="{% url 'myhpom:faq' %}" data-no-ajax="true" target="_blank" rel="noopener noreferrer">
+                                        Learn more in our FAQs
+                                    </a>
                                 </div>
                                 <div class="advance-directive-block-footer__caption">
                                     Link will open in new window

--- a/myhpom/templates/myhpom/accounts/next_steps_no_ad_template.html
+++ b/myhpom/templates/myhpom/accounts/next_steps_no_ad_template.html
@@ -32,12 +32,11 @@
                 <div class="row">
                     <div class="col-12">
                         <h3>Welcome!</h3>
-                        {% scribble 'welcome-text-no-template' 'next_steps' %}
                         <p>
                             Currently, Mind My Health serves North Carolina
                             and South Carolina.
                             <small>
-                                <a href="{% url 'myhpom:home' %}">
+                                <a href="{% url 'myhpom:faq' %}#why_only_north_south_carolina" data-no-ajax="true" target="_blank" rel="noopener noreferrer">
                                     (Why North and South Carolina?)
                                 </a>
                             </small>
@@ -51,7 +50,6 @@
                             You may still store your documents with us
                             and retrieve them upon request.
                         </p>
-                        {% endscribble %}
                         <form method="post" action="{% url 'myhpom:next_steps' %}">
                             {% csrf_token %}
                             <div class="form-group">
@@ -68,7 +66,7 @@
                                     {% if form.errors.custom_provider %}{{ form.errors.custom_provider }}{% endif %}
                                 </div>
                                 <small class="form-text text-muted" id="custom_provider_help">
-                                    <a href="{% url 'myhpom:home' %}">
+                                    <a href="{% url 'myhpom:faq' %}#how_do_i_find_my_healthcare_network" data-no-ajax="true" target="_blank" rel="noopener noreferrer">
                                         How do I find my healthcare network?
                                     </a>
                                 </small>


### PR DESCRIPTION
The scope of this ticket expanded a bit: We needed some new FAQ entries as link targets, so those have been added at the end of the first section.

To test, you'll have to create a new user in a non-supported state (such as Iowa!) and then you can follow the links on the next-steps page. Then in the dashboard edit your state to North Carolina, then you can browse to /accounts/choose-network and /accounts/next-steps and follow the links from there.