### PR TITLE
Mh 261  links in upload no ajax

### DIFF
--- a/myhpom/static/myhpom/data/faq.yaml
+++ b/myhpom/static/myhpom/data/faq.yaml
@@ -94,6 +94,14 @@
     name: why_is_medicare_not_an_option
     answer: Medicare does not operate hospitals or doctor’s offices, so it is not a network. Check with your doctor about their health network or ask them what the network for the nearest hospital is.
     tooltip: Medicare does not operate hospitals or doctor’s offices, so it is not a network. Check with your doctor about their health network or ask them what the network for the nearest hospital is.
+  - question: What is a validation date? 
+    name: what_is_a_validation_date
+    answer: This is the date your advance care document is active legally. It aligns to the final date of a notarization or date identified on the document at the time of signing (whichever represents its legal date).
+    tooltip: This is the date your advance care document is active legally.
+  - question: Why is it important that my advance directive have my name on it? 
+    name: why_is_it_important_that_my_advance_directive_have_my_name_on_it
+    answer: The advance directive is a legal document that guides an individual’s care. We cannot accept a document written for another person. The owner of the Mind My Health account must align to the person whose health decisions are reflected in the document.
+    tooltip: The advance directive is a legal document that guides an individual’s care. We cannot accept a document written for another person.
 
 - name: understanding
   description: Understanding My Plan

--- a/myhpom/templates/myhpom/upload/index.html
+++ b/myhpom/templates/myhpom/upload/index.html
@@ -5,18 +5,17 @@
 <h3 class="h5">
     Requirements for Advance Directive:
 </h3>
-
-{% scribble 'upload-ad-requirements' 'shared' %}
 <p>
-    {% lorem 8 w %}
+    <b>Each state has it's own unique requirements for an advance care plan.</b>
 </p>
 <p>
-    {% lorem 12 w %}
+    These requirements may include the need for 1 or 2 witness signatures and/or a notary.
 </p>
 <p>
-    {% lorem 6 w %}
+    Not sure about what your advance care plan may require, learn more in our
+    <a href="{% url 'myhpom:faq' %}" data-no-ajax="true" target="_blank" rel="noopener noreferrer">Frequently Asked Questions</a>
+    (<a href="{% url 'myhpom:faq' %}" data-no-ajax="true" target="_blank" rel="noopener noreferrer">FAQs</a>).
 </p>
-{% endscribble %}
 
 <div class="advance-directive-widget__buttons-container vertical-flex">
     <div>


### PR DESCRIPTION
A scribbler-inserted link on production in the upload-requirements panel is causing an AJAX link follow. So I fixed the link and whacked the scribbler block. 

Shane also had a couple of late FAQ changes, so I threw them in here for safe keeping.