### PR TITLE
[MH-267] alert link underline color

### DIFF
--- a/myhpom/static/myhpom/_bootstrap_overrides.scss
+++ b/myhpom/static/myhpom/_bootstrap_overrides.scss
@@ -55,6 +55,10 @@ a:not(.btn):not(.img-link):hover {
     border-bottom-width: 2px;
     border-bottom-style: solid;
     border-bottom-color: inherit;
+
+    .alert.alert-warning > & {
+        border-bottom-color: $link-hover-color;
+    }
 }
 
 // Layout


### PR DESCRIPTION
`border-bottom-color: inherit;` typically does the right thing and inherits from `color`, but in this case, it apparently prioritizes inheriting from the `border-color` of an ancestor element, which is not at all what we want.

We can fix this just by being more forceful about demanding that links immediately beneath `.alert.alert-warning` use the desired border color, here `$link-hover-color`.