### PR TITLE
Bail hsctl when a migrate fails.

### DIFF
--- a/hsctl
+++ b/hsctl
@@ -269,6 +269,10 @@ migrate_hs() {
     echo "MIGRATE:"
     echo "  - docker exec -u hydro-service hydroshare python manage.py migrate -v0 --fake-initial --noinput"
     docker exec -u hydro-service hydroshare python manage.py migrate -v0 --fake-initial --noinput
+    exitcode=$?
+    if [[ $exitcode -ne 0 ]]; then
+        exit $exitcode
+    fi
 }
 
 manage_py_hs() {


### PR DESCRIPTION
This script REALLY should use the 'set -e' option, but I'm afraid of how
many other broken things we'll unturn. In the meantime this addresses
the most pressing missing thing.