### PR TITLE
Puts document urls into an AD admin area (MH-278)

### DIFF
--- a/myhpom/admin.py
+++ b/myhpom/admin.py
@@ -3,7 +3,9 @@ from django.contrib import admin
 from myhpom.models.state import State
 from myhpom.models.state_requirement import StateRequirement
 from myhpom.models.state_requirement_link import StateRequirementLink
-from myhpom.models.document import DocumentUrl
+from myhpom.models.document import AdvanceDirective, DocumentUrl
+
+from django.utils.safestring import mark_safe
 
 
 class StateRequirementLinkAdmin(admin.TabularInline):
@@ -26,13 +28,23 @@ class StateAdmin(admin.ModelAdmin):
     inlines = [StateRequirementInlineAdmin]
 
 
-class DocumentUrlAdmin(admin.ModelAdmin):
+class DocumentUrlInlineAdmin(admin.StackedInline):
     model = DocumentUrl
-    readonly_fields = ['key', 'url']
-    list_display = ['url', 'expiration']
-    raw_id_fields = ['advancedirective']
+    fields = ('url_as_link', 'expiration',)
+    readonly_fields = ('url_as_link',)
+    extra = 0
+
+    def url_as_link(self, obj):
+        return mark_safe(
+            '<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>'
+            % (obj.url, obj.url))
+
+
+class AdvanceDirectiveAdmin(admin.ModelAdmin):
+    model = AdvanceDirective
+    inlines = [DocumentUrlInlineAdmin]
 
 
 admin.site.register(State, StateAdmin)
 admin.site.register(StateRequirement, StateRequirementAdmin)
-admin.site.register(DocumentUrl, DocumentUrlAdmin)
+admin.site.register(AdvanceDirective, AdvanceDirectiveAdmin)


### PR DESCRIPTION
There seems to be some slight wonkiness to the admin in that you actually have to change/pick a date in the inline in order for the document url to get created (but that I think is sufficiently unbuggy for backend testing!)