### PR TITLE
Mh 255 notify document reviewed

### DIFF
--- a/myhpom/templates/myhpom/profile/document_review_completed_email.txt
+++ b/myhpom/templates/myhpom/profile/document_review_completed_email.txt
@@ -1,0 +1,12 @@
+{% autoescape off %}
+At Mind My Health we have completed our review of your document! You can view the results on your account dashboard here:
+
+{{ dashboard_url }}
+
+If clicking the link above doesn't work, please copy and paste the URL in a new browser
+window instead.
+
+Sincerely,
+Mind My Health Team
+{% endautoescape %}
+

--- a/myhpom/tests/test_cloudfactory_response_view.py
+++ b/myhpom/tests/test_cloudfactory_response_view.py
@@ -2,7 +2,7 @@ import json
 import os
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-
+from celery.signals import after_task_publish
 from myhpom.models import CloudFactoryDocumentRun
 
 CF_PATH = os.path.join(os.path.dirname(__file__), 'fixtures', 'cloudfactory')
@@ -10,7 +10,6 @@ SUCCESS_DATA = open(os.path.join(CF_PATH, 'callback_success.json')).read()
 
 
 class CloudfactoryResponseTest(TestCase):
-
     def post_json(self, url, data):
         return self.client.post(url, data=data, content_type='text/example')
 
@@ -53,19 +52,23 @@ class CloudfactoryResponseTest(TestCase):
             run.status = CloudFactoryDocumentRun.STATUS_PROCESSING
             run.save()
             response = self.post_json(
-                reverse('myhpom:cloudfactory_response'), json.dumps(failed_data))
+                reverse('myhpom:cloudfactory_response'), json.dumps(failed_data)
+            )
             self.assertEqual(200, response.status_code, '%s=False should return 200' % output)
             run.refresh_from_db()
             # The status and the response should be saved:
             self.assertEqual(
-                CloudFactoryDocumentRun.STATUS_PROCESSED, run.status,
-                '%s=False should transition to processed' % output)
+                CloudFactoryDocumentRun.STATUS_PROCESSED,
+                run.status,
+                '%s=False should transition to processed' % output,
+            )
             self.assertEqual(json.dumps(failed_data), run.response_content)
 
     def test_successful_review(self):
         # We get back a response that says any of the output criteria failed
         run = CloudFactoryDocumentRun.objects.create(
-            run_id='E7gVrtVQJx', status=CloudFactoryDocumentRun.STATUS_PROCESSING)
+            run_id='E7gVrtVQJx', status=CloudFactoryDocumentRun.STATUS_PROCESSING
+        )
 
         response = self.post_json(reverse('myhpom:cloudfactory_response'), SUCCESS_DATA)
         self.assertEqual(200, response.status_code)
@@ -73,3 +76,38 @@ class CloudfactoryResponseTest(TestCase):
         # The status and the response should be saved:
         self.assertEqual(CloudFactoryDocumentRun.STATUS_PROCESSED, run.status)
         self.assertEqual(SUCCESS_DATA, run.response_content)
+
+    def test_user_email_task_on_completed_review(self):
+        """
+        When a review has been completed, the view should trigger the email task.
+        """
+        # this seems to be the way to test whether a task has been called...
+        @after_task_publish.connect(sender='myhpom.tasks.EmailUserDocumentReviewCompleted')
+        def task_sent_handler(sender=None, headers=None, body=None, **kwargs):
+            task_sent_handler.called = True
+
+        task_sent_handler.called = False
+
+        CloudFactoryDocumentRun.objects.create(
+            run_id='E7gVrtVQJx', status=CloudFactoryDocumentRun.STATUS_PROCESSING
+        )
+        response = self.post_json(reverse('myhpom:cloudfactory_response'), SUCCESS_DATA)
+        self.assertEqual(200, response.status_code)  # indicates successful review completion
+        self.assertTrue(task_sent_handler.called)
+
+    def test_user_email_task_on_non_completed_review(self):
+        """
+        If the status is not STATUS_PROCESSING, the view should not trigger the email task.
+        """
+        CloudFactoryDocumentRun.objects.create(
+            run_id='E7gVrtVQJx', status=CloudFactoryDocumentRun.STATUS_PROCESSED
+        )
+
+        @after_task_publish.connect(sender='myhpom.tasks.EmailUserDocumentReviewCompleted')
+        def task_sent_handler(sender=None, headers=None, body=None, **kwargs):
+            task_sent_handler.called = True
+
+        task_sent_handler.called = False
+        response = self.post_json(reverse('myhpom:cloudfactory_response'), SUCCESS_DATA)
+        self.assertEqual(400, response.status_code)  # indicates review non-completion
+        self.assertFalse(task_sent_handler.called)

--- a/myhpom/tests/test_cloudfactory_response_view.py
+++ b/myhpom/tests/test_cloudfactory_response_view.py
@@ -88,7 +88,7 @@ class CloudfactoryResponseTest(TestCase):
         task_sent_handler.called = False
 
         CloudFactoryDocumentRun.objects.create(
-            run_id='E7gVrtVQJx', status=CloudFactoryDocumentRun.STATUS_PROCESSING
+            run_id='SUCCESS_ID', status=CloudFactoryDocumentRun.STATUS_PROCESSING
         )
         response = self.post_json(reverse('myhpom:cloudfactory_response'), SUCCESS_DATA)
         self.assertEqual(200, response.status_code)  # indicates successful review completion
@@ -99,7 +99,7 @@ class CloudfactoryResponseTest(TestCase):
         If the status is not STATUS_PROCESSING, the view should not trigger the email task.
         """
         CloudFactoryDocumentRun.objects.create(
-            run_id='E7gVrtVQJx', status=CloudFactoryDocumentRun.STATUS_PROCESSED
+            run_id='SUCCESS_ID', status=CloudFactoryDocumentRun.STATUS_PROCESSED
         )
 
         @after_task_publish.connect(sender='myhpom.tasks.EmailUserDocumentReviewCompleted')

--- a/myhpom/tests/test_cloudfactory_tasks.py
+++ b/myhpom/tests/test_cloudfactory_tasks.py
@@ -4,11 +4,9 @@ import requests
 import requests_mock
 from django.test import TestCase, override_settings
 from django.conf import settings
-from django.core.files.uploadedfile import SimpleUploadedFile
-from django.utils.timezone import now
 from django.utils.dateparse import parse_datetime
-from myhpom.tests.factories import UserFactory
-from myhpom.models import AdvanceDirective, DocumentUrl, CloudFactoryDocumentRun
+from myhpom.tests.factories import AdvanceDirectiveFactory
+from myhpom.models import DocumentUrl, CloudFactoryDocumentRun
 from myhpom.tasks import (
     CloudFactorySubmitDocumentRun,
     CloudFactoryAbortDocumentRun,
@@ -32,16 +30,7 @@ class CloudFactorySubmitDocumentRunTestCase(TestCase):
     """
 
     def setUp(self):
-        self.document_url = DocumentUrl.objects.create(
-            advancedirective=AdvanceDirective.objects.create(
-                user=UserFactory(),
-                share_with_ehs=False,
-                document=SimpleUploadedFile(
-                    os.path.basename(PDF_FILENAME), open(PDF_FILENAME, 'rb').read()
-                ),
-                valid_date=now(),
-            )
-        )
+        self.document_url = DocumentUrl.objects.create(advancedirective=AdvanceDirectiveFactory())
         self.task = CloudFactorySubmitDocumentRun
 
     def test_201_created(self, reqmock):

--- a/myhpom/tests/test_document_url_model.py
+++ b/myhpom/tests/test_document_url_model.py
@@ -5,11 +5,9 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils.timezone import now
 from django.conf import settings
 from django.db import IntegrityError
-from mock import Mock
 from celery.signals import after_task_publish
 from myhpom.tests.factories import UserFactory
 from myhpom.models import DocumentUrl, AdvanceDirective, CloudFactoryDocumentRun
-from myhpom.tasks import CloudFactoryAbortDocumentRun
 
 
 class DocumentUrlModelTestCase(TestCase):
@@ -115,7 +113,7 @@ class DocumentUrlModelTestCase(TestCase):
 
         ad = self.advancedirective
         doc_url = DocumentUrl.objects.create(advancedirective=ad)
-        cf_run = CloudFactoryDocumentRun.objects.create(
+        CloudFactoryDocumentRun.objects.create(
             document_url=doc_url, status=CloudFactoryDocumentRun.STATUS_PROCESSING, run_id='A_RUN'
         )
         doc_url.delete()

--- a/myhpom/tests/test_documentreview_task.py
+++ b/myhpom/tests/test_documentreview_task.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from django.core import mail
+from myhpom.models import CloudFactoryDocumentRun, DocumentUrl
+from myhpom.tasks import EmailUserDocumentReviewCompleted
+from myhpom.tests.factories import AdvanceDirectiveFactory
+
+
+class EmailUserDocumentReviewCompletedTestCase(TestCase):
+    """
+    * If the corresponding DocumentUrl has been deleted, no email should be sent.
+    * Otherwise, a generic email should be sent to the user who owns the DocumentUrl
+    """
+
+    def setUp(self):
+        self.run = CloudFactoryDocumentRun.objects.create(
+            document_url=DocumentUrl.objects.create(advancedirective=AdvanceDirectiveFactory())
+        )
+        self.task = EmailUserDocumentReviewCompleted
+
+    def test_email_sent(self):
+        self.task(self.run.id, 'http', 'localhost')
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_document_deleted_email_not_sent(self):
+        self.run.document_url.delete()
+        self.task(self.run.id, 'http', 'localhost')
+        self.assertEqual(len(mail.outbox), 0)

--- a/myhpom/views/document.py
+++ b/myhpom/views/document.py
@@ -71,7 +71,7 @@ def cloudfactory_response(request):
         # try/catch here:
         run.save_response_data(body)
 
-        # If the status is STATUS_PROCESSED, this means that the review is 
+        # If the status is now STATUS_PROCESSED, this means that the review is
         # completed and the user should be notified to come view their document.
         # -- In a task so that the CF callback can finish w/o reference to the user notification.
         if run.status == CloudFactoryDocumentRun.STATUS_PROCESSED:


### PR DESCRIPTION
This PR is pretty simple – send an email to the user notifying that the document has been processed. 

I've based this PR off of the current state of MH-253, since that will show the changes most clearly.

This is done in a task rather than directly in the view, since the sending of the email is not the concern of the requester (cloud factory). If the email is supposed to be sent but it fails, we get an error email.