### PR TITLE
Mh 253 bugfixes

### DIFF
--- a/myhpom/models/document.py
+++ b/myhpom/models/document.py
@@ -336,7 +336,7 @@ class CloudFactoryDocumentRun(models.Model):
         unit_data = {
             'full_name': ad.user.get_full_name(),
             'state': ad.user.userdetails.state.name if ad.user.userdetails.state else None,
-            'pdf_url': self.document_host + self.document_url.url,
+            'pdf_url': 'https://%s%s' % (self.document_host, self.document_url.url),
             'date_signed': str(ad.valid_date),
         }
         # Only submit non-blank values, to ensure valid input. (CloudFactory accepts blank values

--- a/myhpom/templates/myhpom/upload/current_ad.html
+++ b/myhpom/templates/myhpom/upload/current_ad.html
@@ -19,7 +19,7 @@ resubmitting the AD for verification.
 {% endcomment %}
 <li class="advance-directive-widget__breadcrumb-status-value--error">In verification</li>
 {% else %}
-<li class="advance-directive-widget__breadcrumb-status-value">Saved</li>
+<li class="advance-directive-widget__breadcrumb-status-value--error">In verification</li>
 {% endif %}
 {% endwith %}
 {% endblock widget_breadcrumb_items %}

--- a/myhpom/tests/fixtures/cloudfactory/callback_abort.json
+++ b/myhpom/tests/fixtures/cloudfactory/callback_abort.json
@@ -8,8 +8,8 @@
       {"input":{
          "date_signed":"2014-02-03",
          "state":"NC",
-         "pdf_url":"mmhdev.mindmyhealth.org/document/ZDkxYmUzOWQtOTYzNy00OWI5LWJlZGQtZWJlNzQyNWM0ZWU0",
-         "full_name":"Gerald Carlton"}
+         "pdf_url":"some URL",
+         "full_name":"Some Name"}
       ,"output":{}
       ,"meta":{
          "status":"Aborted",

--- a/myhpom/tests/fixtures/cloudfactory/callback_abort.json
+++ b/myhpom/tests/fixtures/cloudfactory/callback_abort.json
@@ -1,0 +1,20 @@
+{
+   "id":"ABORT_ID",
+   "line_id":"LINE_ID",
+   "created_at":"2018-10-01T18:26:34.000Z",
+   "processed_at":"2018-10-01T18:39:05.000Z",
+   "status":"Processed",
+   "units":[
+      {"input":{
+         "date_signed":"2014-02-03",
+         "state":"NC",
+         "pdf_url":"mmhdev.mindmyhealth.org/document/ZDkxYmUzOWQtOTYzNy00OWI5LWJlZGQtZWJlNzQyNWM0ZWU0",
+         "full_name":"Gerald Carlton"}
+      ,"output":{}
+      ,"meta":{
+         "status":"Aborted",
+         "created_at":"2018-10-01T18:26:34.000Z",
+         "processed_at":"2018-10-01T18:39:05Z"}
+      }
+   ]
+}

--- a/myhpom/tests/fixtures/cloudfactory/callback_success.json
+++ b/myhpom/tests/fixtures/cloudfactory/callback_success.json
@@ -1,6 +1,6 @@
 {
    "id": "SUCCESS_ID",
-   "line_id": "zUyZv59Mxi",
+   "line_id": "LINE_ID",
    "created_at": "2015-09-03T09:18:38Z",
    "processed_at": "2015-09-03T09:39:21Z",
    "status": "Processed",

--- a/myhpom/tests/test_cloudfactory_response_view.py
+++ b/myhpom/tests/test_cloudfactory_response_view.py
@@ -3,8 +3,8 @@ import os
 from mock import patch
 from django.core.urlresolvers import reverse
 from django.test import TestCase
-from celery.signals import after_task_publish
 from myhpom.models import CloudFactoryDocumentRun
+from myhpom.tests.factories import CloudFactoryDocumentRunFactory
 
 CF_PATH = os.path.join(os.path.dirname(__file__), 'fixtures', 'cloudfactory')
 SUCCESS_DATA = open(os.path.join(CF_PATH, 'callback_success.json')).read()
@@ -30,6 +30,18 @@ class CloudfactoryResponseTest(TestCase):
         # Record doesn't exist on our end - we want a log of this.
         response = self.post_json(reverse('myhpom:cloudfactory_response'), SUCCESS_DATA)
         self.assertEqual(404, response.status_code)
+
+    def test_no_output(self):
+        # When no output is in the json, a 4xx code is returned,
+        # alerting the requestor that the problem is theirs
+        run = CloudFactoryDocumentRunFactory(
+            run_id='SUCCESS_ID', status=CloudFactoryDocumentRun.STATUS_PROCESSING)
+        no_output = json.loads(SUCCESS_DATA)
+        del no_output['units'][0]['output']
+        response = self.post_json(reverse('myhpom:cloudfactory_response'), json.dumps(no_output))
+        self.assertEqual(400, response.status_code)
+        run.refresh_from_db()
+        self.assertEqual(CloudFactoryDocumentRun.STATUS_ERROR, run.status)
 
     def test_already_finished(self):
         # When CloudFactoryDocumentRun exists, but it is already 'finished' - we

--- a/myhpom/tests/test_cloudfactory_response_view.py
+++ b/myhpom/tests/test_cloudfactory_response_view.py
@@ -48,9 +48,8 @@ class CloudfactoryResponseTest(TestCase):
         # When an abort happens, we should handle it gracefully.
         run = CloudFactoryDocumentRunFactory(
             run_id='ABORT_ID', status=CloudFactoryDocumentRun.STATUS_ABORTED)
-        no_output = json.loads(ABORT_DATA)
-        response = self.post_json(reverse('myhpom:cloudfactory_response'), json.dumps(no_output))
-        print("response = {0}".format(response))
+        abort_data = json.loads(ABORT_DATA)
+        response = self.post_json(reverse('myhpom:cloudfactory_response'), json.dumps(abort_data))
         self.assertEqual(200, response.status_code)
         run.refresh_from_db()
         self.assertEqual(CloudFactoryDocumentRun.STATUS_ABORTED, run.status)

--- a/myhpom/views/document.py
+++ b/myhpom/views/document.py
@@ -62,19 +62,22 @@ def cloudfactory_response(request):
     except CloudFactoryDocumentRun.DoesNotExist:
         raise Http404()
     else:
-        # A run in a final state shouldn't be changed/updated again. Log an
-        # error.
-        if run.status in CloudFactoryDocumentRun.STATUS_FINAL_STATES:
-            return HttpResponseBadRequest()
+        try:
+            # A run in a final state shouldn't be changed/updated again. Log an
+            # error.
+            if run.status in CloudFactoryDocumentRun.STATUS_FINAL_STATES:
+                return HttpResponseBadRequest('Unexpected callback')
 
-        # We already know that the body is parseable JSON so there is no need to
-        # try/catch here:
-        run.save_response_data(body)
+            # We already know that the body is parseable JSON so there is no need to
+            # try/catch here:
+            run.save_response_data(body)
+        except ValueError as e:
+            return HttpResponseBadRequest(e.message)
+        else:
+            # If the status is now STATUS_PROCESSED, this means that the review is
+            # completed and the user should be notified to come view their document.
+            # -- In a task so that the CF callback can finish w/o reference to the user notification.
+            if run.status == CloudFactoryDocumentRun.STATUS_PROCESSED:
+                EmailUserDocumentReviewCompleted.delay(run.id, request.scheme, request.get_host())
 
-        # If the status is now STATUS_PROCESSED, this means that the review is
-        # completed and the user should be notified to come view their document.
-        # -- In a task so that the CF callback can finish w/o reference to the user notification.
-        if run.status == CloudFactoryDocumentRun.STATUS_PROCESSED:
-            EmailUserDocumentReviewCompleted.delay(run.id, request.scheme, request.get_host())
-
-        return HttpResponse()
+            return HttpResponse()

--- a/myhpom/views/document.py
+++ b/myhpom/views/document.py
@@ -56,6 +56,12 @@ def cloudfactory_response(request):
         if 'id' not in json_body:
             return HttpResponseBadRequest('No id found in json body')
 
+        # An aborted run should be ignored.
+        if 'units' in json_body and len(json_body['units']) > 0:
+            unit = json_body['units'][0]
+            if 'meta' in unit and unit['meta']['status'] == CloudFactoryDocumentRun.STATUS_ABORTED:
+                return HttpResponse()
+
         run = CloudFactoryDocumentRun.objects.get(run_id=json_body['id'])
     except ValueError:
         return HttpResponseBadRequest('Unable to parse json body')

--- a/myhpom/views/verification.py
+++ b/myhpom/views/verification.py
@@ -36,7 +36,7 @@ def send_account_verification(request):
                     },
                     request=request,
                 ),
-                settings.CONTACT_EMAIL,
+                settings.DEFAULT_FROM_EMAIL,
                 [request.user.email],
                 fail_silently=False,
             )


### PR DESCRIPTION
Several small-ish bugfixes:

 * Change 'saved' to 'in verification' as discussed.
 * Fix unexpected 500s when unable to save the json sent to a callback (created during our testing with Gerald).
 * Use the no-reply email for email verification (I realized we DO use the contact email for uh...duh!...sending emails to MMH admins, so I left CONTACT_EMAIL alone).
 * Ignore CF callbacks for aborted runs (we already know and don't care)