### PR TITLE
[MH-252] Ensure that one cannot accidentally create multiple documents.

### DIFF
--- a/myhpom/tests/test_upload_view.py
+++ b/myhpom/tests/test_upload_view.py
@@ -129,7 +129,20 @@ class DirectiveUploadRequirementsTestCase(GETMixin, TestCase):
         self.assertIsNotNone(user.advancedirective.document)
         self.assertIsNotNone(user.advancedirective.thumbnail)
         self.assertEqual(1, user.advancedirective.documenturl_set.count())
-        task_patch.delay.assert_called_with(
+        task_patch.delay.assert_called_once_with(
+            user.advancedirective.documenturl_set.first().pk, 'testserver')
+
+        # Subsequent posts do not cause more tasks/documents to be created
+        response = self.client.post(
+            self.url, data=post_data, HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+        self.assertRedirects(
+            response, reverse('myhpom:upload_current_ad'), fetch_redirect_response=False
+        )
+        self.assertIsNotNone(user.advancedirective.document)
+        self.assertIsNotNone(user.advancedirective.thumbnail)
+        self.assertEqual(1, user.advancedirective.documenturl_set.count())
+        task_patch.delay.assert_called_once_with(
             user.advancedirective.documenturl_set.first().pk, 'testserver')
 
     @patch('myhpom.views.upload.CloudFactorySubmitDocumentRun')

--- a/myhpom/views/upload.py
+++ b/myhpom/views/upload.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.views.decorators.http import require_GET, require_POST, require_http_methods
 from django.shortcuts import render, redirect
-from django.http import HttpResponseForbidden, HttpResponseRedirect
+from django.http import HttpResponseForbidden, HttpResponseRedirect, HttpResponseBadRequest
 from django.core.urlresolvers import reverse
 from django.utils.timezone import now
 
@@ -37,11 +37,9 @@ def upload_requirements(request):
     POST: store the advance directive date, redirect to the upload/submit view.
     """
     if hasattr(request.user, 'advancedirective'):
-        directive = request.user.advancedirective
-    else:
-        directive = AdvanceDirective(user=request.user, share_with_ehs=False)
-    MIN_YEAR = 1950
+        return redirect(reverse("myhpom:upload_current_ad"))
 
+    directive = AdvanceDirective(user=request.user, share_with_ehs=False)
     if request.method == "POST":
         form = UploadRequirementsForm(request.POST, request.FILES, instance=directive)
         if form.is_valid():
@@ -57,6 +55,7 @@ def upload_requirements(request):
     else:
         form = UploadRequirementsForm(instance=directive)
 
+    MIN_YEAR = 1950
     context = {
         'user': request.user,
         'form': form,

--- a/myhpom/views/upload.py
+++ b/myhpom/views/upload.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.views.decorators.http import require_GET, require_POST, require_http_methods
 from django.shortcuts import render, redirect
-from django.http import HttpResponseForbidden, HttpResponseRedirect, HttpResponseBadRequest
+from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.core.urlresolvers import reverse
 from django.utils.timezone import now
 


### PR DESCRIPTION
This change ensures that only one document is uploaded when a user has
multiple tabs open on the dashboard - when the user clicks 'upload'
rather than seeing the requirements page they will see the uploaded
document.

There is a case where the user could have two tabs open, both on the
'upload requirements' page - and the second submit would do nothing.
This seems like not worth showing an error, but maybe my reviewer will
feel different!