### PR TITLE
[MH-176] Add template tag for organ donor link

### DIFF
--- a/myhpom/templates/myhpom/dashboard.html
+++ b/myhpom/templates/myhpom/dashboard.html
@@ -1,5 +1,5 @@
 {% extends "myhpom/base.html" %}
-{% load sass_tags static %}
+{% load sass_tags static mmh_tags %}
 
 {% block extra-head %}
 <script type="text/javascript" src="{% static "myhpom/moment/min/moment.min.js" %}"></script>
@@ -67,7 +67,7 @@
                             <span class="h5 dashboard-profile-information__status">I am not an organ donor.</span>
                         </div>
                         <div>
-                            <a href="http://donatelifenc.org/Register" alt="Donate Life" class="dashboard-profile-information__organ-donor-link" target="_blank" rel="noopener noreferrer">
+                            <a href="{% organ_donor_info_url request.user.userdetails.state %}" alt="Donate Life" class="dashboard-profile-information__organ-donor-link" target="_blank" rel="noopener noreferrer">
                                 Learn how you can be a donor.
                             </a>
                         </div>

--- a/myhpom/templates/myhpom/profile/edit.html
+++ b/myhpom/templates/myhpom/profile/edit.html
@@ -1,5 +1,5 @@
 {% extends "myhpom/profile/view.html" %}
-{% load sass_tags static %}
+{% load sass_tags static mmh_tags %}
 
 {% block extra-head %}
 <script type="text/javascript" src="{% static "myhpom/moment/min/moment.min.js" %}"></script>
@@ -154,7 +154,7 @@
                     <br/>
                 </p>
                 <div class="profile__info-box__link">
-                    <a href="http://donatelifenc.org/Register" alt="Donate Life" target="_blank" rel="noopener noreferrer">
+                    <a href="{% organ_donor_info_url request.user.userdetails.state %}" alt="Donate Life" target="_blank" rel="noopener noreferrer">
                         Learn how you can be a donor.
                     </a>
                 </div>

--- a/myhpom/templatetags/mmh_tags.py
+++ b/myhpom/templatetags/mmh_tags.py
@@ -1,0 +1,20 @@
+from django import template
+
+
+register = template.Library()
+
+
+SUPPORTED_STATE_ORGAN_DONOR_INFO_URLS = {
+    'NC': 'https://www.donatelifenc.org/register/',
+    'SC': 'https://www.donatelifesc.org/register/',
+}
+
+DEFAULT_ORGAN_DONOR_INFO_URL = 'https://www.donatelife.net/register/'
+
+
+@register.simple_tag
+def organ_donor_info_url(state):
+    return SUPPORTED_STATE_ORGAN_DONOR_INFO_URLS.get(
+        state.name,
+        DEFAULT_ORGAN_DONOR_INFO_URL,
+    )

--- a/myhpom/tests/test_templatetags.py
+++ b/myhpom/tests/test_templatetags.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+
+from myhpom.models import State
+from myhpom.templatetags import mmh_tags
+
+
+class OrganDonorInfoTest(TestCase):
+    def test_nc_sc(self):
+        """
+        Supported states (as of Oct 8, 2018) return their own
+        organ donor info links.
+        """
+        for name in mmh_tags.SUPPORTED_STATE_ORGAN_DONOR_INFO_URLS.keys():
+            state = State(
+                name=name,
+                title='Some Irrelevant Title'
+            )
+            info_url = mmh_tags.organ_donor_info_url(state)
+            self.assertEqual(
+                info_url,
+                mmh_tags.SUPPORTED_STATE_ORGAN_DONOR_INFO_URLS.get(
+                    state.name,
+                    'default',
+                )
+            )
+
+    def test_other(self):
+        """
+        Unsupported states return a default URL.
+        """
+        other = State(
+            name='EN',
+            title='East New York',
+        )
+        other_info_url = mmh_tags.organ_donor_info_url(other)
+
+        self.assertEqual(
+            mmh_tags.DEFAULT_ORGAN_DONOR_INFO_URL,
+            other_info_url,
+        )

--- a/myhpom/views/profile.py
+++ b/myhpom/views/profile.py
@@ -5,7 +5,6 @@ from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
 from myhpom.forms.profile import EditUserForm, EditUserDetailsForm
 from myhpom.models.user import User
-from datetime import datetime
 
 
 @require_http_methods(['GET'])


### PR DESCRIPTION
Adds a dictionary of supported states' organ donor info URLs and a simple accessor template tag to expose it.