### PR TITLE
[MH-289] Use explicit POST to delete and redirect to requirements page.

### DIFF
--- a/myhpom/static/myhpom/include/_upload_widget.scss
+++ b/myhpom/static/myhpom/include/_upload_widget.scss
@@ -154,6 +154,10 @@
     align-items: flex-start;
 }
 
+.advance-directive-widget__change-file-form {
+    flex-shrink: 0;
+}
+
 .advance-directive-widget__change-file {
     flex-shrink: 0;
     margin-left: 1rem;

--- a/myhpom/templates/myhpom/upload/index.html
+++ b/myhpom/templates/myhpom/upload/index.html
@@ -5,13 +5,13 @@
     Requirements for Advance Directive:
 </h3>
 <p>
-    <b>Each state has it's own unique requirements for an advance care plan.</b>
+    <b>Each state has its own unique requirements for an advance care plan.</b>
 </p>
 <p>
     These requirements may include the need for 1 or 2 witness signatures and/or a notary.
 </p>
 <p>
-    Not sure about what your advance care plan may require, learn more in our
+    Not sure about what your advance care plan may require? Learn more in our
     <a href="{% url 'myhpom:faq' %}" data-no-ajax="true" target="_blank" rel="noopener noreferrer">Frequently Asked Questions
     (FAQs)</a>.
 </p>

--- a/myhpom/templates/myhpom/upload/sharing.html
+++ b/myhpom/templates/myhpom/upload/sharing.html
@@ -20,6 +20,7 @@
     </div>
     <form
         id="delete_and_redirect_to_requiremennts"
+        class="advance-directive-widget__change-file-form"
         action="{% url "myhpom:upload_delete_ad" %}?redirect={% url "myhpom:upload_requirements" %}"
         method="POST"
     >

--- a/myhpom/templates/myhpom/upload/sharing.html
+++ b/myhpom/templates/myhpom/upload/sharing.html
@@ -18,7 +18,14 @@
         <span class="h6">You have selected:</span>
         <span class="advance-directive-widget__filename">{{ request.user.advancedirective.filename }}</span>
     </div>
-    <a class="advance-directive-widget__change-file" href="{% url "myhpom:upload_requirements" %}">change file</a>
+    <form
+        id="delete_and_redirect_to_requiremennts"
+        action="{% url "myhpom:upload_delete_ad" %}?redirect={% url "myhpom:upload_requirements" %}"
+        method="POST"
+    >
+        {% csrf_token %}
+        <a class="advance-directive-widget__change-file" data-no-ajax="true" data-post="" href="#">change file</a>
+    </form>
 </div>
 
 <hr/>
@@ -35,3 +42,19 @@
     <button class="advance-directive-widget__button--primary" type="submit">Submit</button>
 </form>
 {% endblock widget_body %}
+
+{% block widget-js %}
+<script>
+jQuery(function ($) {
+    /*
+        Unfortunately, when grabbed via AJAX, the modal trigger
+        will not be initialized automatically. We can pretend
+        this is taking place by assigning a click handler.
+    */
+    $('[data-post]').on('click', function (e) {
+        e.preventDefault();
+        $(this).parent('form').submit();
+    });
+});
+</script>
+{% endblock %}

--- a/myhpom/views/upload.py
+++ b/myhpom/views/upload.py
@@ -90,6 +90,6 @@ def upload_sharing(request):
 def upload_delete_ad(request):
     if hasattr(request.user, 'advancedirective'):
         request.user.advancedirective.delete()
-        return HttpResponseRedirect(reverse('myhpom:upload_index'))
+        return HttpResponseRedirect(request.GET.get('redirect', (reverse('myhpom:upload_index'))))
     else:
         return HttpResponseRedirect(reverse('myhpom:upload_current_ad'))


### PR DESCRIPTION
The requirements endpoint no longer automatically re-uses an existing
AD - so I've made the 'change form' explicitly delete and then redirect
to the requirements page.